### PR TITLE
fix: harden browser ownership, reconnects, and compaction recovery

### DIFF
--- a/src/adapters/chatgpt-web/browser-helper-main.ts
+++ b/src/adapters/chatgpt-web/browser-helper-main.ts
@@ -187,6 +187,7 @@ async function run(message: RunMessage): Promise<void> {
     ...(message.turn.compaction ? { compaction: true } : {}),
     abortSignal: abortController.signal,
     onHeartbeat: () => writeProtocol({ type: "event", id: message.id, event: "heartbeat" }),
+    onSendActivated: () => writeProtocol({ type: "event", id: message.id, event: "send_activated" }),
     onSubmitted: () => writeProtocol({ type: "event", id: message.id, event: "submitted" }),
     onPreparedSelected: reused => {
       writeProtocol({ type: "event", id: message.id, event: "prepared_selected", reused });

--- a/src/adapters/chatgpt-web/browser-worker.ts
+++ b/src/adapters/chatgpt-web/browser-worker.ts
@@ -459,6 +459,8 @@ export interface BrowserTurn {
   onHeartbeat?: () => void;
   /** Semantic DOM progress used only to reset the upstream silence timer. */
   onProgress?: () => void;
+  /** Send activation is an irreversible ambiguity boundary: never replay on a fresh surface. */
+  onSendActivated?: () => void;
   /** The current prompt is visible to ChatGPT and must never be replayed on another surface. */
   onSubmitted?: () => void;
   /** Release the unselected full/resume transport after the launcher resolves the retained lease. */
@@ -809,9 +811,14 @@ export class ChatGptBrowserWorker {
   }
 
   private async runWithSurfaceRetry(turn: BrowserTurn): Promise<string> {
+    let sendActivated = false;
     let submitted = false;
     const submittedTurn: BrowserTurn = {
       ...turn,
+      onSendActivated: () => {
+        sendActivated = true;
+        turn.onSendActivated?.();
+      },
       onSubmitted: () => {
         submitted = true;
         turn.onSubmitted?.();
@@ -829,6 +836,7 @@ export class ChatGptBrowserWorker {
         || (error.code !== "chatgpt_surface_changed" && error.code !== "chatgpt_connector_unavailable")
         || !error.retryable
         || (adapterOwnsRecovery && error.code !== "chatgpt_connector_unavailable")
+        || sendActivated
         || submitted
         || turn.abortSignal?.aborted) throw error;
       console.warn(`[chatgpt-web] browser turn ${turn.traceId} retrying once on a fresh surface`);
@@ -1274,6 +1282,7 @@ export class ChatGptBrowserWorker {
     initialResponseTurn: ChatGptAssistantTurnState,
     captureDiagnostic?: (checkpoint: string) => Promise<void>,
     abortSignal?: AbortSignal,
+    onSendActivated?: () => void,
   ): Promise<ChatGptSubmissionEvidence> {
     const composer = await this.activeComposer(page);
     const sendButton = composer
@@ -1286,6 +1295,7 @@ export class ChatGptBrowserWorker {
     await settleChatGptUi();
     await captureDiagnostic?.("send-ready");
     await throwIfChatGptSessionFailureAlert(page);
+    onSendActivated?.();
     await activateChatGptSendControl(sendButton);
     return this.waitForSubmissionAccepted(
       page,
@@ -2466,6 +2476,7 @@ export class ChatGptBrowserWorker {
               initialResponseTurn,
               checkpoint => diagnostics.capture(page, `multipart-${index + 1}-${checkpoint}`),
               turn.abortSignal ? AbortSignal.any([stageSignal, turn.abortSignal]) : stageSignal,
+              turn.onSendActivated,
             ),
             turn.abortSignal,
           );
@@ -2602,6 +2613,7 @@ export class ChatGptBrowserWorker {
         await settleChatGptUi();
         await diagnostics.capture(page, "send-ready");
         await throwIfChatGptSessionFailureAlert(page);
+        turn.onSendActivated?.();
         await activateChatGptSendControl(sendButton);
         const evidence = await this.waitForSubmissionAccepted(
           page,

--- a/src/adapters/chatgpt-web/compaction-handoff.ts
+++ b/src/adapters/chatgpt-web/compaction-handoff.ts
@@ -8,7 +8,6 @@ import { structuredCompactionHandoffInstruction } from "./native-compaction-cont
 
 export const COMPACTION_HANDOFF_MARKER = "CODEX_COMPACTION_HANDOFF";
 export const LATEST_USER_PROMPT_MARKER = "CODEX_LATEST_USER_PROMPT_JSON";
-const ACTIVE_HANDOFF_TIMEOUT_MESSAGE = "active browser handoff timed out";
 
 export const HANDOFF_INSTRUCTION = `Automatic Codex context compaction has started. Do not call any more tools.
 ${COMPACT_PROMPT}
@@ -146,31 +145,20 @@ function retryableBrowserFailure(error: unknown): boolean {
     || error.message.includes("completed text block");
 }
 
-async function waitForBrowser(
+async function rejectOnBrowserFailure(
   session: ChatGptTurnSession,
-  signal: AbortSignal | undefined,
-  timeoutMs: number,
-): Promise<ChatGptBrowserOutcome> {
-  if (signal?.aborted) {
-    throw new DOMException("ChatGPT web compaction aborted", "AbortError");
+  broker: TurnBroker,
+  transactionToken: string,
+): Promise<never> {
+  const outcome: ChatGptBrowserOutcome = await session.browserOutcome;
+  if (outcome.type === "error") {
+    broker.abortCompactionTransaction(transactionToken);
+    throw outcome.error;
   }
-  let timer: ReturnType<typeof setTimeout> | undefined;
-  let onAbort: (() => void) | undefined;
-  const timeout = new Promise<never>((_resolve, reject) => {
-    timer = setTimeout(() => reject(new Error(ACTIVE_HANDOFF_TIMEOUT_MESSAGE)), timeoutMs);
-  });
-  const aborted = signal
-    ? new Promise<never>((_resolve, reject) => {
-      onAbort = () => reject(new DOMException("ChatGPT web compaction aborted", "AbortError"));
-      signal.addEventListener("abort", onAbort, { once: true });
-    })
-    : new Promise<never>(() => {});
-  try {
-    return await Promise.race([session.browserOutcome, timeout, aborted]);
-  } finally {
-    if (timer) clearTimeout(timer);
-    if (signal && onAbort) signal.removeEventListener("abort", onAbort);
-  }
+  // A clean browser completion cannot make a structured checkpoint appear later, but the broker
+  // submission may still be crossing the local socket. Keep waiting on the transaction itself;
+  // its bounded TTL remains the authoritative deadline.
+  return new Promise<never>(() => {});
 }
 
 export async function requestActiveCompactionHandoff(
@@ -184,6 +172,9 @@ export async function requestActiveCompactionHandoff(
   if (cached) return cached;
   if (!session.isActive()) return undefined;
   if (session.runtime.mode === "read-only" && !session.runtime.requestHandoff) return undefined;
+  if (signal?.aborted) {
+    throw new DOMException("ChatGPT web compaction aborted", "AbortError");
+  }
   const transaction = await broker.beginCompactionTransaction(
     session.runtime.conversationKey ?? "active-compaction",
     timeoutMs,
@@ -216,14 +207,14 @@ export async function requestActiveCompactionHandoff(
       const preempted = session.runtime.preemptHandoff?.(instruction) === true;
       session.runtime.requestHandoff!(instruction, preempted);
     }
-    const browserCompleted = waitForBrowser(session, signal, timeoutMs).then(outcome => {
-      if (outcome.type === "error") {
-        broker.abortCompactionTransaction(transaction.token);
-        throw outcome.error;
-      }
-      return outcome;
-    });
-    const [summary] = await Promise.all([structuredHandoff, browserCompleted]);
+    // The one-shot control submission contains the complete checkpoint and is validated by the
+    // broker before it resolves. Once present it is stronger evidence than a fragile ChatGPT DOM
+    // completion control; runEnhancedCompaction retires the remaining browser work before exposing
+    // the checkpoint to Codex.
+    const summary = await Promise.race([
+      structuredHandoff,
+      rejectOnBrowserFailure(session, broker, transaction.token),
+    ]);
     session.setCompactionHandoff(summary);
     return summary;
   } catch (error) {

--- a/src/adapters/chatgpt-web/enhanced-compaction.ts
+++ b/src/adapters/chatgpt-web/enhanced-compaction.ts
@@ -83,14 +83,14 @@ export async function runEnhancedCompaction(
     );
     return "completed";
   }
-  console.warn("[chatgpt-web] Web session mode=enhanced path=active_handoff result=unavailable");
-  throw new ChatGptWebAdapterError(
-    "Enhanced Web session mode could not obtain a checkpoint from the active ChatGPT Web conversation. Retry the compact request or disable enhanced mode to use the original compact path.",
-    {
-      status: 409,
-      errorType: "invalid_request_error",
-      code: "compaction_handoff_unavailable",
-      retryable: false,
-    },
+  // The source-side handoff is an optimization. If its bounded attempt cannot produce a validated
+  // checkpoint, retire that surface and rebuild once from Codex's canonical request in this same
+  // HTTP compact operation. This is the exact recovery a client reconnect previously triggered,
+  // without surfacing a false failure or asking Codex to repeat an ambiguous request.
+  await chatGptTurnSessions.retireAndWait(responseExecutionKey);
+  console.warn(
+    "[chatgpt-web] Web session mode=enhanced path=active_handoff"
+    + " result=checkpoint_unavailable action=rebuild",
   );
+  return "rebuild";
 }

--- a/src/adapters/chatgpt-web/index.ts
+++ b/src/adapters/chatgpt-web/index.ts
@@ -97,7 +97,7 @@ export function createChatGptWebAdapter(
     let activeToken: string | undefined;
     let toolResultDelivered = false;
     const toolEvidence = mode.localTools && !parsed._compactionRequest ? new ChatGptToolEvidenceGuard() : undefined;
-    const submission = { accepted: false };
+    const submission: NonNullable<ChatGptTurnRuntime["submission"]> = { phase: "prepared" };
     const handoffPrompts = useEnhancedWebSessionMode ? createActiveCompactionHandoffPrompts() : undefined;
     const runtimeExecutionKey = `${executionNamespace}:${chatGptTurnExecutionKey(parsed)}`;
     const { retainConversation: requestedRetention, retryPromptForAnswer: upstreamRetry } = claudeBrowserTurnOptions(
@@ -149,7 +149,8 @@ export function createChatGptWebAdapter(
         onReasoningSummary: (value, continuation) => trace.push({ kind: "reasoning", text: value, ...(continuation ? { continuation: true } : {}) }),
         onCommentary: emitCommentary,
         onProgress: () => trace.signalProgress(),
-        onSubmitted: () => { submission.accepted = true; },
+        onSendActivated: () => { submission.phase = "send_activated"; },
+        onSubmitted: () => { submission.phase = "accepted"; },
         onTextDelta: delta => text.push(delta),
         ...(retryPromptForAnswer ? { retryPromptForAnswer } : {}),
         ...(retryPromptForError ? { retryPromptForError } : {}),
@@ -206,7 +207,8 @@ export function createChatGptWebAdapter(
       onReasoningSummary: (text, continuation) => trace.push({ kind: "reasoning", text, ...(continuation ? { continuation: true } : {}) }),
       onCommentary: emitCommentary,
       onProgress: () => trace.signalProgress(),
-      onSubmitted: () => { submission.accepted = true; },
+      onSendActivated: () => { submission.phase = "send_activated"; },
+      onSubmitted: () => { submission.phase = "accepted"; },
       onTextDelta: delta => text.push(delta),
       ...(retryPromptForAnswer ? { retryPromptForAnswer } : {}),
       ...(retryPromptForError ? { retryPromptForError } : {}),

--- a/src/adapters/chatgpt-web/launcher-helper-client.ts
+++ b/src/adapters/chatgpt-web/launcher-helper-client.ts
@@ -226,6 +226,9 @@ export class LauncherBrowserHelperClient {
       if (message.event === "heartbeat") {
         this.invokeEventCallback(message.id, pending, () => pending.turn.onHeartbeat?.());
       }
+      else if (message.event === "send_activated") {
+        this.invokeEventCallback(message.id, pending, () => pending.turn.onSendActivated?.());
+      }
       else if (message.event === "submitted") {
         this.invokeEventCallback(message.id, pending, () => pending.turn.onSubmitted?.());
       }

--- a/src/adapters/chatgpt-web/launcher-helper-protocol.ts
+++ b/src/adapters/chatgpt-web/launcher-helper-protocol.ts
@@ -5,7 +5,7 @@ import {
 
 export type LauncherHelperMessage =
   | { type: "ready" }
-  | { type: "event"; id: string; event: "heartbeat" | "submitted" | "retry_submitted" | "reasoning" | "commentary" | "text"; text?: string; continuation?: boolean }
+  | { type: "event"; id: string; event: "heartbeat" | "send_activated" | "submitted" | "retry_submitted" | "reasoning" | "commentary" | "text"; text?: string; continuation?: boolean }
   | { type: "event"; id: string; event: "prepared_selected"; reused: boolean }
   | { type: "event"; id: string; event: "answer"; text: string; attempt: number }
   | {
@@ -108,7 +108,7 @@ function parseEvent(message: Record<string, unknown> & { id: string }): Launcher
     }
     return { type: "event", id: message.id, event, reused: message.reused };
   }
-  if (!["heartbeat", "submitted", "retry_submitted", "reasoning", "commentary", "text"].includes(String(event))) {
+  if (!["heartbeat", "send_activated", "submitted", "retry_submitted", "reasoning", "commentary", "text"].includes(String(event))) {
     throw new Error("Launcher browser helper emitted an unknown event");
   }
   if (message.text !== undefined && typeof message.text !== "string") {
@@ -120,7 +120,7 @@ function parseEvent(message: Record<string, unknown> & { id: string }): Launcher
   return {
     type: "event",
     id: message.id,
-    event: event as "heartbeat" | "submitted" | "retry_submitted" | "reasoning" | "commentary" | "text",
+    event: event as "heartbeat" | "send_activated" | "submitted" | "retry_submitted" | "reasoning" | "commentary" | "text",
     ...(message.text !== undefined ? { text: message.text as string } : {}),
     ...(message.continuation !== undefined ? { continuation: message.continuation as boolean } : {}),
   };

--- a/src/adapters/chatgpt-web/prompt.ts
+++ b/src/adapters/chatgpt-web/prompt.ts
@@ -465,9 +465,11 @@ export function compileChatGptWebPrompt(
       "Never emulate a stateful or persistent tool with codex_exec, shell commands, or a temporary language process. If discovery or loading fails, report only the observed failure and do not attempt that fallback.",
       "Codex Native shell_command is one-shot: do not request a TTY or expect later stdin. Use APIs compatible with the active platform shell, pipe generated input inside the same command, and never print secret values.",
       "Request independent tool calls together when their inputs do not depend on one another; keep dependent calls sequential.",
-      "Use actual Codex Native results as evidence for local observations and effects, and keep calling tools until the requested work is complete and verified.",
+      "Use actual Codex Native results as evidence for local observations and effects.",
       "Describe failed local actions using only observable tool evidence. If no native result was returned, state only that the action did not execute; never infer or name an unreported cause.",
+      "After a deterministic tool failure, update the working hypothesis from that result and inspect the relevant repository or environment before choosing a different next action; do not repeat the same call unless its inputs or observable state changed.",
       ...(toolPolicy.requireTool ? ["You must execute at least one of the request-authorized local tools before returning a final answer."] : []),
+      "Continue using the available tools until the requested work is complete and verified.",
     ]
     : [
       nativeControlConnector

--- a/src/adapters/chatgpt-web/retained-compaction-handoff.ts
+++ b/src/adapters/chatgpt-web/retained-compaction-handoff.ts
@@ -8,18 +8,16 @@ import { chatGptConversationKey, type ChatGptTurnSession } from "./turn-executio
 
 const RETAINED_CONVERSATION_UNAVAILABLE = "The retained ChatGPT conversation is no longer available";
 const RETAINED_BROWSER_CLEANUP_TIMEOUT_MS = 15_000;
-const RETAINED_BROWSER_COMPLETION_TIMEOUT = "The retained checkpoint Web response did not complete before timeout";
 
-async function waitForBrowserCompletion(browser: Promise<string>, timeoutMs: number): Promise<string> {
-  let timer: ReturnType<typeof setTimeout> | undefined;
-  const deadline = new Promise<never>((_resolve, reject) => {
-    timer = setTimeout(() => reject(new Error(RETAINED_BROWSER_COMPLETION_TIMEOUT)), timeoutMs);
-  });
+async function rejectOnBrowserFailure(browser: Promise<string>): Promise<never> {
   try {
-    return await Promise.race([browser, deadline]);
-  } finally {
-    if (timer) clearTimeout(timer);
+    await browser;
+  } catch (error) {
+    throw error;
   }
+  // A clean Web completion can race the local structured submission. The transaction owns the
+  // bounded deadline, so let its result decide whether a checkpoint exists.
+  return new Promise<never>(() => {});
 }
 
 async function waitForBrowserCleanup(browser: Promise<string>, timeoutMs: number): Promise<boolean> {
@@ -78,11 +76,11 @@ export async function requestRetainedCompactionHandoff(
       abortSignal: browserAbort.signal,
       onTextDelta: () => {},
     });
-    const [handoff] = await Promise.all([
+    const handoff = await Promise.race([
       structuredHandoff,
-      waitForBrowserCompletion(browserCompleted, timeoutMs),
+      rejectOnBrowserFailure(browserCompleted),
     ]);
-    console.info("[chatgpt-web] Web session mode=enhanced path=retained_handoff result=completed");
+    console.info("[chatgpt-web] Web session mode=enhanced path=retained_handoff result=checkpoint_submitted");
     return handoff;
   } catch (error) {
     if (error instanceof DOMException && error.name === "AbortError") throw error;

--- a/src/adapters/chatgpt-web/runtime-lifecycle.ts
+++ b/src/adapters/chatgpt-web/runtime-lifecycle.ts
@@ -55,6 +55,7 @@ export type ChatGptSurfaceRecoveryReason =
   | "read_only"
   | "unsupported_error"
   | "non_retryable"
+  | "submission_activated"
   | "final_streamed"
   | "canonical_incomplete"
   | "superseded_results_pending"
@@ -141,6 +142,7 @@ export function chatGptSurfaceRecoveryDecision(
   if (recoveries > 0) return reject("already_recovered");
   if (signal?.aborted) return reject("aborted");
   if (session.runtime.mode !== "tools") return reject("read_only");
+  if (session.runtime.submission?.phase === "send_activated") return reject("submission_activated");
   const surfaceFailure = error instanceof ChatGptWebAdapterError
     && (error.code === "chatgpt_surface_changed"
       || error.code === "chatgpt_connector_unavailable"

--- a/src/adapters/chatgpt-web/submitted-turn.ts
+++ b/src/adapters/chatgpt-web/submitted-turn.ts
@@ -2,20 +2,29 @@ import { StallTimeoutError } from "../../stall-timeout";
 import { ChatGptWebAdapterError } from "./adapter-error";
 import type { ChatGptTurnSession } from "./turn-execution";
 
-function terminalError(error: unknown): ChatGptWebAdapterError {
+function terminalError(error: unknown, phase: "send_activated" | "accepted"): ChatGptWebAdapterError {
+  const ambiguous = phase === "send_activated";
   return new ChatGptWebAdapterError(
-    `ChatGPT failed after accepting the Web prompt: ${error instanceof Error ? error.message : String(error)}`,
-    { status: 502, errorType: "server_error", code: "chatgpt_submitted_turn_failed", retryable: false },
+    ambiguous
+      ? `ChatGPT Send was activated, but acceptance could not be proven; the prompt will not be resent: ${error instanceof Error ? error.message : String(error)}`
+      : `ChatGPT failed after accepting the Web prompt: ${error instanceof Error ? error.message : String(error)}`,
+    {
+      status: 502,
+      errorType: "server_error",
+      code: ambiguous ? "chatgpt_submission_ambiguous" : "chatgpt_submitted_turn_failed",
+      retryable: false,
+    },
   );
 }
 
 function submittedFailure(
   session: ChatGptTurnSession,
-  aborted: boolean,
+  _aborted: boolean,
   error: unknown,
 ): ChatGptWebAdapterError | undefined {
-  if (aborted || !session.runtime.submission?.accepted) return undefined;
-  const terminal = terminalError(error);
+  const phase = session.runtime.submission?.phase;
+  if (!phase || phase === "prepared") return undefined;
+  const terminal = terminalError(error, phase);
   session.setTerminalError(terminal);
   return terminal;
 }

--- a/src/adapters/chatgpt-web/turn-execution.ts
+++ b/src/adapters/chatgpt-web/turn-execution.ts
@@ -29,7 +29,7 @@ interface ChatGptTurnRuntimeBase {
   preemptHandoff?: (instruction: string) => boolean;
   requestHandoff?: (instruction: string, instructionDelivered?: boolean) => void;
   onToolResultDelivered?: (result?: CodexToolResultMessage) => void;
-  submission?: { accepted: boolean };
+  submission?: { phase: "prepared" | "send_activated" | "accepted" };
   cancel: (reason?: Error) => void;
   /** Release a completed retained browser surface when this canonical session is superseded. */
   release?: () => Promise<void>;
@@ -304,8 +304,25 @@ export class ChatGptTurnSessions {
   ): Promise<ChatGptTurnSession> {
     for (;;) {
       const pending = this.retirements.get(key) ?? (conversationKey ? this.conversationRetirements.get(conversationKey) : undefined);
-      if (!pending) return this.getOrCreate(key, start, group, steeringId, claudeRootThreadId, traceId);
-      await pending;
+      if (pending) {
+        await pending;
+        continue;
+      }
+      const activeOwner = conversationKey
+        ? [...this.entries].find(([ownedKey, session]) => (
+            ownedKey !== key
+            && session.runtime.conversationKey === conversationKey
+            && session.isActive()
+          ))
+        : undefined;
+      if (activeOwner) {
+        const [ownedKey, ownedSession] = activeOwner;
+        if (this.entries.get(ownedKey) !== ownedSession) continue;
+        this.entries.delete(ownedKey);
+        await this.beginRetirement(ownedKey, ownedSession);
+        continue;
+      }
+      return this.getOrCreate(key, start, group, steeringId, claudeRootThreadId, traceId);
     }
   }
 
@@ -380,7 +397,7 @@ export class ChatGptTurnSessions {
     const retirement = trackConversationRetirement(
       this.retirements, key, session.browserOutcome.then(async () => { await release?.(); }),
     );
-    if (release && session.runtime.conversationKey) {
+    if (session.runtime.conversationKey) {
       trackConversationRetirement(this.conversationRetirements, session.runtime.conversationKey, retirement);
     }
     return retirement;

--- a/tests/browser-worker-contract.test.ts
+++ b/tests/browser-worker-contract.test.ts
@@ -58,6 +58,10 @@ test("browser turn orchestration retains owned prompt insertion and semantic sub
   expect(runBrowserTurn).toContain('.locator("xpath=ancestor::form[1]")');
   expect(runBrowserTurn).toContain('.getByTestId("send-button")');
   expect(runBrowserTurn).toContain("await activateChatGptSendControl(sendButton)");
+  expect(runBrowserTurn.indexOf("turn.onSendActivated?.()"))
+    .toBeGreaterThanOrEqual(0);
+  expect(runBrowserTurn.indexOf("turn.onSendActivated?.()"))
+    .toBeLessThan(runBrowserTurn.indexOf("await activateChatGptSendControl(sendButton)"));
   expect(runBrowserTurn).toContain("await this.waitForSubmissionAccepted(");
   expect(workerSource).not.toMatch(/\bclipboard\b|pbcopy|pbpaste/i);
 });

--- a/tests/chatgpt-surface-resilience.test.ts
+++ b/tests/chatgpt-surface-resilience.test.ts
@@ -112,6 +112,34 @@ describe("ChatGPT Web surface resilience", () => {
     expect(attempts).toBe(1);
   });
 
+  test("does not retry a fresh surface after the Send control was activated", async () => {
+    const Worker = ChatGptBrowserWorker as unknown as new (config: object) => ChatGptBrowserWorker;
+    const worker = new Worker({ browserHost: "managed-chrome" });
+    let attempts = 0;
+    let activated = false;
+    type ActivationAwareTurn = BrowserTurn & { onSendActivated?: () => void };
+    (worker as unknown as { runExclusive: (turn: ActivationAwareTurn) => Promise<string> }).runExclusive = async turn => {
+      attempts += 1;
+      if (attempts === 1) {
+        turn.onSendActivated?.();
+        throw chatGptWebSurfaceError("submission evidence disappeared after Send activation", false);
+      }
+      return "duplicate submission";
+    };
+
+    const result = worker.run({
+      traceId: "surface-send-activated-no-retry",
+      modelId: CHATGPT_WEB_MODEL_ID,
+      reasoning: "high",
+      capabilities: { localToolsEnabled: false, solAvailable: true, proAvailable: true },
+      onSendActivated: () => { activated = true; },
+    } as ActivationAwareTurn);
+
+    await expect(result).rejects.toMatchObject({ code: "chatgpt_surface_changed" });
+    expect(activated).toBeTrue();
+    expect(attempts).toBe(1);
+  });
+
   test("leaves tool-capable fresh-surface recovery to the adapter", async () => {
     const Worker = ChatGptBrowserWorker as unknown as new (config: object) => ChatGptBrowserWorker;
     const worker = new Worker({ browserHost: "managed-chrome" });

--- a/tests/chatgpt-web-harness.test.ts
+++ b/tests/chatgpt-web-harness.test.ts
@@ -1693,6 +1693,43 @@ describe("ChatGPT outer-native harness v4", () => {
     }
   });
 
+  test("an ambiguous post-activation failure is replayed without resending the Web prompt", async () => {
+    const socketPath = brokerTestEndpoint(`cgw-h4-activated-retry-${process.pid}-${Date.now()}`);
+    const provider: CodexProviderConfig = {
+      adapter: "chatgpt-web",
+      baseUrl: "browser://chatgpt-activated-retry-test",
+      chatgptWeb: { brokerSocketPath: socketPath, localToolsEnabled: false, solAvailable: true, proAvailable: true },
+    };
+    const worker = ChatGptBrowserWorker.forProvider(provider);
+    const originalRun = worker.run.bind(worker);
+    let browserStarts = 0;
+    type ActivationAwareTurn = BrowserTurn & { onSendActivated?: () => void };
+    (worker as unknown as { run: (turn: ActivationAwareTurn) => Promise<string> }).run = async turn => {
+      browserStarts += 1;
+      turn.onSendActivated?.();
+      throw chatGptWebSurfaceError("submission evidence disappeared after Send activation", false);
+    };
+    try {
+      for (let attempt = 0; attempt < 2; attempt += 1) {
+        const events: AdapterEvent[] = [];
+        await createChatGptWebAdapter(provider).runTurn!(
+          rawWireRequest(environmentXml),
+          { headers: new Headers() },
+          event => events.push(event),
+        );
+        expect(events.at(-1)).toMatchObject({
+          type: "error",
+          code: "chatgpt_submission_ambiguous",
+          retryable: false,
+        });
+      }
+      expect(browserStarts).toBe(1);
+    } finally {
+      (worker as unknown as { run: (turn: BrowserTurn) => Promise<string> }).run = originalRun;
+      await TurnBroker.forSocket(socketPath).close();
+    }
+  });
+
   test("keeps a conversation key across Codex turns and rotates it after compaction", () => {
     const first = rawWireRequest(environmentXml);
     const next = structuredClone(first);

--- a/tests/compact-mode-routing.test.ts
+++ b/tests/compact-mode-routing.test.ts
@@ -188,6 +188,51 @@ describe("compact mode routing", () => {
     }
   });
 
+  test("rebuilds in the same compact request when an active source cannot submit a checkpoint", async () => {
+    const sourceRequest = compactRequest();
+    delete sourceRequest._compactionRequest;
+    const parsed = compactRequest();
+    const socketPath = defaultBrokerEndpoint(join(
+      tmpdir(),
+      `compact-active-fallback-${process.pid}-${Date.now()}`,
+    ));
+    const broker = TurnBroker.forSocket(socketPath);
+    const responseExecutionKey = `active-fallback-${process.pid}-${Date.now()}`;
+    let finishBrowser!: (answer: string) => void;
+    let cancelled = 0;
+    chatGptTurnSessions.getOrCreate(responseExecutionKey, () => ({
+      mode: "read-only",
+      browser: new Promise<string>(resolve => { finishBrowser = resolve; }),
+      trace: new ChatGptTraceFeed(),
+      text: new ChatGptTextFeed(),
+      usageInput: sourceRequest,
+      cancel: () => {
+        cancelled += 1;
+        finishBrowser("source retired for canonical rebuild");
+      },
+    }));
+
+    try {
+      await expect(runEnhancedCompaction({
+        worker: { run: async () => "unused" } as never,
+        parsed,
+        broker,
+        executionNamespace: createHash("sha256").update("active-fallback-namespace").digest("hex"),
+        capabilities: { localToolsEnabled: false, solAvailable: true, proAvailable: true },
+        responseExecutionKey,
+        nativeConnectorAvailable: true,
+        timeoutMs: 20,
+        emit: () => {},
+      })).resolves.toBe("rebuild");
+
+      expect(cancelled).toBe(1);
+      expect(chatGptTurnSessions.find(responseExecutionKey)).toBeUndefined();
+    } finally {
+      await chatGptTurnSessions.retireAndWait(responseExecutionKey);
+      await broker.close();
+    }
+  });
+
   test("does not attach enhanced handoff behavior to original-mode browser turns", async () => {
     const config = provider(false);
     const worker = ChatGptBrowserWorker.forProvider(config);

--- a/tests/launcher-helper-client.test.ts
+++ b/tests/launcher-helper-client.test.ts
@@ -29,6 +29,7 @@ test("Bun daemon prepares only the resume prompt selected by the persistent Node
         if (message.prepared?.text !== "continue") process.exit(3);
         message = selected;
         selected = undefined;
+        send({ type: "event", id: message.id, event: "send_activated" });
         send({ type: "event", id: message.id, event: "submitted" });
         send({ type: "event", id: message.id, event: "reasoning", text: " files", continuation: true });
         send({ type: "event", id: message.id, event: "text", text: "done" });
@@ -97,6 +98,7 @@ test("Bun daemon prepares only the resume prompt selected by the persistent Node
   const reasoning: Array<{ text: string; continuation: boolean }> = [];
   const deltas: string[] = [];
   const checkpoints: unknown[] = [];
+  let sendActivated = false;
   let submitted = false;
   let released = false;
   let resumeReleased = false;
@@ -122,6 +124,7 @@ test("Bun daemon prepares only the resume prompt selected by the persistent Node
       requireRetainedConversation: true,
       conversationKey: "a".repeat(64),
       onReasoningSummary: (text, continuation) => reasoning.push({ text, continuation: continuation === true }),
+      onSendActivated: () => { sendActivated = true; },
       onSubmitted: () => { submitted = true; },
       onTextDelta: text => deltas.push(text),
       captureLunaCheckpoint: true,
@@ -135,6 +138,7 @@ test("Bun daemon prepares only the resume prompt selected by the persistent Node
       { text: " files", continuation: true },
     ]);
     expect(deltas).toEqual(["done"]);
+    expect(sendActivated).toBe(true);
     expect(submitted).toBe(true);
     expect(checkpoints).toEqual([{
       answerHash: "a".repeat(64),

--- a/tests/prompt-contract.test.ts
+++ b/tests/prompt-contract.test.ts
@@ -60,7 +60,11 @@ test("tool-capable prompts pass one stable turn token directly to native actions
   expect(tokenMatches).toHaveLength(1);
   expect(compiled.text).toContain("[retired turn handle]");
   expect(transportOnly).toContain("For local work required by the task, use the attached Codex Native tools directly according to their declared descriptions and schemas.");
-  expect(transportOnly).toContain("Use actual Codex Native results as evidence for local observations and effects, and keep calling tools until the requested work is complete and verified.");
+  expect(transportOnly).toContain("Use actual Codex Native results as evidence for local observations and effects.");
+  expect(transportOnly).toContain("After a deterministic tool failure, update the working hypothesis from that result");
+  expect(transportOnly).toContain("inspect the relevant repository or environment before choosing a different next action");
+  expect(transportOnly).toContain("do not repeat the same call unless its inputs or observable state changed");
+  expect(transportOnly).toContain("Continue using the available tools until the requested work is complete and verified.");
   expect(transportOnly).toContain("Request independent tool calls together");
   expect(transportOnly).toContain("A skill catalog entry is an instruction source, not proof that its runtime tool is loaded.");
   expect(transportOnly).toContain("codex_tool_inventory");

--- a/tests/retained-compaction-handoff.test.ts
+++ b/tests/retained-compaction-handoff.test.ts
@@ -154,7 +154,7 @@ test("retained Enhanced compact cleanup stays bounded when the browser ignores a
   }
 });
 
-test("retained Enhanced compact stays bounded after structured handoff when the browser never completes", async () => {
+test("retained Enhanced compact preserves a structured handoff when browser completion evidence never arrives", async () => {
   const namespace = createHash("sha256").update("retained-compact-structured-timeout-test").digest("hex");
   const source = new ChatGptTurnSession({
     mode: "read-only", browser: Promise.resolve("done"), trace: new ChatGptTraceFeed(),
@@ -183,5 +183,5 @@ test("retained Enhanced compact stays bounded after structured handoff when the 
   ), Bun.sleep(200).then(() => "browser-timeout" as const)]);
 
   expect(handoff).not.toBe("browser-timeout");
-  expect(handoff).toBeUndefined();
+  expect(handoff).toBe("Structured retained checkpoint is valid.");
 });

--- a/tests/runtime-lifecycle.test.ts
+++ b/tests/runtime-lifecycle.test.ts
@@ -163,6 +163,22 @@ test("surface recovery rejects read-only and non-retryable turns", () => {
   )).toMatchObject({ eligible: false, reason: "non_retryable" });
 });
 
+test("tool surface recovery cannot rebuild after Send activation", () => {
+  const tools = new ChatGptTurnSession({
+    mode: "tools",
+    token: Promise.resolve("turn_activated"),
+    browser: new Promise<string>(() => {}),
+    trace: new ChatGptTraceFeed(),
+    text: new ChatGptTextFeed(),
+    submission: { phase: "send_activated" },
+    cancel: () => {},
+  });
+
+  expect(chatGptSurfaceRecoveryDecision(
+    chatGptWebSurfaceError("surface changed", false), tools, completeRequest(), 0,
+  )).toMatchObject({ eligible: false, reason: "submission_activated" });
+});
+
 test("surface recovery diagnostics identify the error that reached the decision boundary", () => {
   const session = new ChatGptTurnSession({
     mode: "tools",

--- a/tests/structured-compaction-handoff.test.ts
+++ b/tests/structured-compaction-handoff.test.ts
@@ -43,7 +43,7 @@ function controlBinding(instruction: string): { token: string; handoffId: string
   return { token, handoffId };
 }
 
-test("active structured compact waits for the Web conversation to end after a valid handoff", async () => {
+test("active structured compact accepts a valid checkpoint before fragile Web completion evidence", async () => {
   const root = mkdtempSync(join(tmpdir(), "cgw-active-structured-"));
   const broker = TurnBroker.forSocket(defaultBrokerEndpoint(root));
   let finishBrowser!: (answer: string) => void;
@@ -75,18 +75,13 @@ test("active structured compact waits for the Web conversation to end after a va
     cancel: () => {},
   } as never);
   try {
-    let settled = false;
-    const compact = requestActiveCompactionHandoff(request(true), session, broker, undefined, 1_000)
-      .then(value => { settled = true; return value; });
+    const compact = requestActiveCompactionHandoff(request(true), session, broker, undefined, 1_000);
     while (!submitted) await Bun.sleep(1);
     await submitted;
-    await Bun.sleep(10);
     expect(preemptions).toBe(1);
     expect(handoffDelivered).toBeTrue();
-    expect(settled).toBeFalse();
-
-    finishBrowser("The checkpoint Web turn has fully ended.");
     await expect(compact).resolves.toBe("Structured active checkpoint is valid.");
+    finishBrowser("The checkpoint Web turn was retired after its structured submission.");
   } finally {
     await broker.close();
     rmSync(root, { recursive: true, force: true });
@@ -213,7 +208,7 @@ test("active structured compact attaches its one-shot handoff to only one result
   expect(queuedHandoffs).toBe(0);
 });
 
-test("retained structured compact requires both a valid control submission and a completed Web turn", async () => {
+test("retained structured compact stops the Web response after a valid control submission", async () => {
   const root = mkdtempSync(join(tmpdir(), "cgw-retained-structured-"));
   const broker = TurnBroker.forSocket(defaultBrokerEndpoint(root));
   const namespace = createHash("sha256").update("retained-structured").digest("hex");
@@ -225,9 +220,9 @@ test("retained structured compact requires both a valid control submission and a
     usageInput: request(false),
     cancel: () => {},
   });
-  let finishBrowser!: (answer: string) => void;
   let submitted!: Promise<unknown>;
   let turn: BrowserTurn | undefined;
+  let browserAborted = false;
   const worker = { run: async (value: BrowserTurn) => {
     turn = value;
     const prepared = await value.prepare();
@@ -239,11 +234,15 @@ test("retained structured compact requires both a valid control submission and a
       handoffId: binding.handoffId,
       summary: "Structured retained checkpoint is valid.",
     });
-    return new Promise<string>(resolve => { finishBrowser = resolve; });
+    return new Promise<string>((_resolve, reject) => {
+      value.abortSignal?.addEventListener("abort", () => {
+        browserAborted = true;
+        reject(new DOMException("retained checkpoint retired", "AbortError"));
+      }, { once: true });
+    });
   } };
 
   try {
-    let settled = false;
     const compact = requestRetainedCompactionHandoff(
       worker as never,
       request(true),
@@ -252,16 +251,14 @@ test("retained structured compact requires both a valid control submission and a
       namespace,
       { localToolsEnabled: true, solAvailable: true, proAvailable: true },
       "trace_retained_structured",
-    ).then(value => { settled = true; return value; });
+    );
     while (!submitted) await Bun.sleep(1);
     await submitted;
-    await Bun.sleep(10);
-    expect(settled).toBeFalse();
     expect(turn?.nativeConnector).toBeTrue();
     expect(turn?.requireRetainedConversation).toBeTrue();
 
-    finishBrowser("The retained checkpoint Web turn has fully ended.");
     await expect(compact).resolves.toBe("Structured retained checkpoint is valid.");
+    expect(browserAborted).toBeTrue();
   } finally {
     await broker.close();
     rmSync(root, { recursive: true, force: true });

--- a/tests/turn-session-retirement.test.ts
+++ b/tests/turn-session-retirement.test.ts
@@ -75,6 +75,36 @@ test("a replacement owner waits for ordinary retirement of the same conversation
   expect(replacements).toBe(1);
 });
 
+test("a new execution cannot overlap an active owner of the same conversation", async () => {
+  const sessions = new ChatGptTurnSessions();
+  let finishBrowser!: (answer: string) => void;
+  const browser = new Promise<string>(resolve => { finishBrowser = resolve; });
+  let cancelled = 0;
+  sessions.getOrCreate("old-execution", () => settledRuntime({
+    browser,
+    conversationKey: "shared-conversation",
+    cancel: () => { cancelled += 1; },
+  }));
+
+  let replacements = 0;
+  const replacement = sessions.getOrCreateAfterConversationRetirement(
+    "new-execution",
+    "shared-conversation",
+    () => {
+      replacements += 1;
+      return settledRuntime({ conversationKey: "shared-conversation" });
+    },
+  );
+  await Bun.sleep(0);
+
+  expect(cancelled).toBe(1);
+  expect(replacements).toBe(0);
+
+  finishBrowser("cancelled");
+  await replacement;
+  expect(replacements).toBe(1);
+});
+
 test("an overlapping same-key retirement includes the replacement owner", async () => {
   const sessions = new ChatGptTurnSessions();
   let finishRelease!: () => void;


### PR DESCRIPTION
## Summary

This PR adds two focused reliability layers on top of v3.0.3-Enhanced.1:

- serialize browser ownership per Codex thread and keep retirement barriers alive until the previous surface has actually stopped;
- make same-trace reconnects join the active turn and replay its final result instead of opening duplicate browser work;
- preserve submitted-turn ownership across ambiguous disconnects to avoid blind resends;
- make validated structured checkpoints authoritative for both active and retained compaction, without depending on fragile DOM completion evidence;
- when an active checkpoint cannot be obtained, retire the old surface and rebuild from Codex canonical context inside the same compact request instead of returning a false failure that forces a reconnect;
- improve the Web prompt contract after deterministic tool failures: update the working hypothesis, inspect relevant state, and do not repeat an unchanged failed call.

## Motivation

The observed failures were orphan/double tabs after Ctrl+C, duplicate work during reconnects, and successful compactions being reported as failed when browser completion evidence raced or stalled. The changes separate durable browser retirement from the session registry and treat the structured broker checkpoint as the authoritative compaction result.

This does not claim to eliminate unrelated browser, network, rate-limit, or future DOM-drift failures.

## Validation

- full Bun test suite passed;
- TypeScript typecheck passed;
- runtime build passed;
- manual long multi-tool task completed with tool-error recovery and final verification;
- mid-turn steering and cancellation completed without further tool calls;
- Ctrl+C followed by resume preserved context without concurrent orphan tabs;
- active and retained compaction recovery paths were exercised successfully.