### PR TITLE
fix: keep native tool turns alive during silent work

### DIFF
--- a/src/adapters/chatgpt-web/browser-worker.ts
+++ b/src/adapters/chatgpt-web/browser-worker.ts
@@ -588,6 +588,59 @@ interface ChatGptResponseDomSnapshot {
   stoppedThinkingVisible: boolean;
   projection: ChatGptFinalProjectionState;
   traceBlocks: ChatGptVisibleTraceBlock[];
+  nativeToolActivity?: ChatGptNativeToolActivity;
+}
+
+export type ChatGptNativeToolActivity = "web_search" | "native_tool";
+
+export const CHATGPT_NATIVE_TOOL_ACTIVITY_PULSE_MS = 120_000;
+const CHATGPT_NATIVE_TOOL_ACTIVITY_DISAPPEARANCE_GRACE_MS = 5_000;
+
+/** Keep a Responses wait alive and expose bounded progress while ChatGPT visibly owns a native tool. */
+export class ChatGptNativeToolActivityTracker {
+  private activity?: ChatGptNativeToolActivity;
+  private startedAt?: number;
+  private missingSince?: number;
+  private lastPulseAt?: number;
+
+  observe(activity: ChatGptNativeToolActivity | undefined, running: boolean, now = Date.now()): string | undefined {
+    if (!running) {
+      this.reset();
+      return undefined;
+    }
+    if (!activity) {
+      this.missingSince ??= now;
+      if (now - this.missingSince >= CHATGPT_NATIVE_TOOL_ACTIVITY_DISAPPEARANCE_GRACE_MS) {
+        this.reset();
+      }
+      return undefined;
+    }
+    if (this.activity !== activity
+      || (this.missingSince !== undefined
+        && now - this.missingSince >= CHATGPT_NATIVE_TOOL_ACTIVITY_DISAPPEARANCE_GRACE_MS)) {
+      this.activity = activity;
+      this.startedAt = now;
+      this.lastPulseAt = undefined;
+    }
+    this.missingSince = undefined;
+    if (this.lastPulseAt !== undefined
+      && now - this.lastPulseAt < CHATGPT_NATIVE_TOOL_ACTIVITY_PULSE_MS) {
+      return undefined;
+    }
+    const elapsedMinutes = Math.floor(Math.max(0, now - (this.startedAt ?? now)) / 60_000);
+    this.lastPulseAt = now;
+    const label = activity === "web_search" ? "Recherche Web" : "Outil ChatGPT";
+    return elapsedMinutes >= 2
+      ? `${label} toujours en cours (${elapsedMinutes} min)`
+      : `${label} en cours`;
+  }
+
+  private reset(): void {
+    this.activity = undefined;
+    this.startedAt = undefined;
+    this.missingSince = undefined;
+    this.lastPulseAt = undefined;
+  }
 }
 
 const absentResponseDomSnapshot = (): ChatGptResponseDomSnapshot => ({
@@ -2135,6 +2188,12 @@ export class ChatGptBrowserWorker {
         ...block,
         ...(block.kind === "commentary" ? { complete: index < blocks.length - 1 } : {}),
       }));
+      const webSearchActivityVisible = [...root.querySelectorAll<HTMLElement>(
+        '[data-testid="cot-v5-favicon"]',
+      )].some(renderedInDom);
+      const nativeToolActivityVisible = webSearchActivityVisible || [...root.querySelectorAll<HTMLElement>(
+        '[data-testid="cot-v5-native-tool-icon"], [data-testid="cot-v5-tool-icon-pile"]',
+      )].some(renderedInDom);
       const stoppedThinkingVisible = (() => {
         if ([...root.querySelectorAll<HTMLElement>('[aria-label="Stopped thinking"]')].some(renderedInDom)) {
           return true;
@@ -2160,6 +2219,11 @@ export class ChatGptBrowserWorker {
         stoppedThinkingVisible,
         projection,
         traceBlocks,
+        ...(webSearchActivityVisible
+          ? { nativeToolActivity: "web_search" as const }
+          : nativeToolActivityVisible
+            ? { nativeToolActivity: "native_tool" as const }
+            : {}),
       };
     }, CHATGPT_COMPLETION_ACTION_SELECTOR, { timeout: 2_000 }).catch(() => {
       if (responseTurn.page().isClosed()) {
@@ -2657,6 +2721,7 @@ export class ChatGptBrowserWorker {
         const completionTracker = new ChatGptCompletionTracker();
         const domHealthTracker = new ChatGptTurnDomHealthTracker();
         const stoppedThinkingTracker = new ChatGptStoppedThinkingTracker();
+        const nativeToolActivityTracker = new ChatGptNativeToolActivityTracker();
         for (;;) {
         if (page.isClosed()) {
           throw chatGptWebSurfaceError("ChatGPT browser tab was closed while the turn was active", answerBuffer.deliveredChars() > 0);
@@ -2765,6 +2830,14 @@ export class ChatGptBrowserWorker {
         );
         if (running) sawRunning = true;
         if (snapshot.responsePresent) {
+          const nativeToolActivity = nativeToolActivityTracker.observe(
+            snapshot.nativeToolActivity,
+            running,
+          );
+          if (nativeToolActivity) {
+            turn.onReasoningSummary?.(nativeToolActivity, false);
+            turn.onProgress?.();
+          }
           const currentProgressChars = snapshot.markdownRoots.reduce(
             (total, root) => total + root.text.length,
             0,

--- a/tests/browser-worker-contract.test.ts
+++ b/tests/browser-worker-contract.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import type { Page } from "playwright-core";
-import { CHATGPT_COMPOSER_DOCUMENT_END_KEY, CHATGPT_PROMPT_INSERT_CHUNK_CHARS, CHATGPT_STOPPED_THINKING_GRACE_MS, ChatGptBrowserWorker, ChatGptCompletionTracker, ChatGptPromptAttachmentIntegrityError, ChatGptStoppedThinkingTracker, ChatGptTurnDomHealthTracker, ChatGptVisibleTraceTracker, MAX_CHATGPT_BROWSER_TABS, MAX_CHATGPT_CONNECTOR_TRIGGER_ATTEMPTS, assertChatGptWebInputWithinLimits, browserDiagnosticCheckpoint, browserDiagnosticIncludesScreenshot, chatGptSubmissionEvidence, isChatGptTraceControl, redactChatGptUiDiagnostic, resolveBrowserConfig, resolveChatGptToolConfirmation, stripChatGptTraceControlSuffix, throwIfChatGptRateLimitDialog, throwIfChatGptSessionFailureAlert, throwIfChatGptTerminalErrorAlert } from "../src/adapters/chatgpt-web/browser-worker";
+import { CHATGPT_COMPOSER_DOCUMENT_END_KEY, CHATGPT_NATIVE_TOOL_ACTIVITY_PULSE_MS, CHATGPT_PROMPT_INSERT_CHUNK_CHARS, CHATGPT_STOPPED_THINKING_GRACE_MS, ChatGptBrowserWorker, ChatGptCompletionTracker, ChatGptNativeToolActivityTracker, ChatGptPromptAttachmentIntegrityError, ChatGptStoppedThinkingTracker, ChatGptTurnDomHealthTracker, ChatGptVisibleTraceTracker, MAX_CHATGPT_BROWSER_TABS, MAX_CHATGPT_CONNECTOR_TRIGGER_ATTEMPTS, assertChatGptWebInputWithinLimits, browserDiagnosticCheckpoint, browserDiagnosticIncludesScreenshot, chatGptSubmissionEvidence, isChatGptTraceControl, redactChatGptUiDiagnostic, resolveBrowserConfig, resolveChatGptToolConfirmation, stripChatGptTraceControlSuffix, throwIfChatGptRateLimitDialog, throwIfChatGptSessionFailureAlert, throwIfChatGptTerminalErrorAlert } from "../src/adapters/chatgpt-web/browser-worker";
 import { CHATGPT_WEB_MODEL_ID } from "../src/adapters/chatgpt-web/model";
 import { compileChatGptWebPrompt } from "../src/adapters/chatgpt-web/prompt";
 import { ChatGptWebAdapterError } from "../src/adapters/chatgpt-web/adapter-error";
@@ -72,6 +72,36 @@ test("browser completion waits for transient Markdown prefix recovery", () => {
   expect(completion).toContain("markdownBuffer.currentSnapshotIsConsistent()");
   expect(completion.indexOf("markdownBuffer.currentSnapshotIsConsistent()"))
     .toBeLessThan(completion.indexOf("markdownBuffer.finish()"));
+});
+
+test("visible native tools keep long silent browser work alive at bounded intervals", () => {
+  expect(CHATGPT_NATIVE_TOOL_ACTIVITY_PULSE_MS).toBe(120_000);
+  const tracker = new ChatGptNativeToolActivityTracker();
+
+  expect(tracker.observe("web_search", true, 1_000)).toBe("Recherche Web en cours");
+  expect(tracker.observe("web_search", true, 120_999)).toBeUndefined();
+  expect(tracker.observe("web_search", true, 121_000)).toBe("Recherche Web toujours en cours (2 min)");
+  expect(tracker.observe("web_search", true, 241_000)).toBe("Recherche Web toujours en cours (4 min)");
+});
+
+test("native tool activity distinguishes generic tools and resets after completion", () => {
+  const tracker = new ChatGptNativeToolActivityTracker();
+
+  expect(tracker.observe("native_tool", true, 10_000)).toBe("Outil ChatGPT en cours");
+  expect(tracker.observe(undefined, true, 11_000)).toBeUndefined();
+  expect(tracker.observe("native_tool", true, 12_000)).toBeUndefined();
+  expect(tracker.observe(undefined, true, 20_000)).toBeUndefined();
+  expect(tracker.observe(undefined, true, 25_000)).toBeUndefined();
+  expect(tracker.observe("native_tool", true, 26_000)).toBe("Outil ChatGPT en cours");
+  expect(tracker.observe(undefined, false, 27_000)).toBeUndefined();
+  expect(tracker.observe("native_tool", true, 28_000)).toBe("Outil ChatGPT en cours");
+});
+
+test("response DOM scopes native tool activity to the owned assistant turn", () => {
+  const workerSource = readFileSync(new URL("../src/adapters/chatgpt-web/browser-worker.ts", import.meta.url), "utf8");
+  expect(workerSource).toContain('[data-testid="cot-v5-favicon"]');
+  expect(workerSource).toContain('[data-testid="cot-v5-native-tool-icon"], [data-testid="cot-v5-tool-icon-pile"]');
+  expect(workerSource).toContain("nativeToolActivityTracker.observe(");
 });
 
 test("persistent Stopped thinking is a terminal cancelled turn", () => {


### PR DESCRIPTION
## Summary

- Detect visible ChatGPT-native tool activity inside the owned assistant turn.
- Distinguish Web search from other native tools using the current response DOM markers.
- Emit an immediate activity status and bounded 120-second pulses through the existing reasoning/progress channel.
- Reset activity after generation completes or the tool DOM remains absent for the grace period.
- Leave browser ownership, submission acknowledgement, replay, retirement, and compaction paths unchanged.

## Why

A ChatGPT-native search or tool can remain active without producing assistant Markdown. The Responses round can therefore reach its 300-second semantic stall timeout even though Web work is still progressing. This patch keeps that wait alive only while the owned response has visible native-tool DOM and generation is running. It deliberately does not use the Stop button alone, so a genuinely stuck generation is not kept alive indefinitely.

Thank you for the careful review of the earlier lifecycle PR and for fixing process-boundary activation acknowledgement and physical browser settlement in Enhanced.2. This follow-up is intentionally isolated from those lifecycle paths.

## Validation

- bun test tests/browser-worker-contract.test.ts: 89 pass, 0 fail
- bun run typecheck: pass
- Full root suite: 94 test files passed in isolated Bun processes
- bun run build: pass
- bun run smoke: RELOCATABLE_RUNTIME_SMOKE_OK

The deployed build was also exercised in real use:

- ChatGPT-native Web research completed after 3m46 without reconnecting.
- A 12m27 repository task completed with many sequential tools and mid-turn user steering.
- Interrupt/resume, Git commit, repository creation, and push workflows completed without duplicate or overlapping Web turns.

The Codex TUI can render the emitted status as its generic Working indicator depending on the client, but the bounded progress pulse still reaches the existing round-progress path.