### PR TITLE
fix: allow Temporary Chat without a personalization toggle

### DIFF
--- a/src/chatgpt-session.ts
+++ b/src/chatgpt-session.ts
@@ -108,14 +108,21 @@ export async function assertTemporaryChatPage(page: Page): Promise<void> {
   }
 }
 
-export async function ensureChatGptTemporaryChatPersonalized(page: Page): Promise<void> {
+export async function ensureChatGptTemporaryChatPersonalized(
+  page: Page,
+  options: { controlTimeoutMs?: number } = {},
+): Promise<void> {
   const buttons = page.locator(CHATGPT_TEMPORARY_CHAT_MODE_BUTTON_SELECTOR).filter({ visible: true });
-  const deadline = Date.now() + 5_000;
+  const deadline = Date.now() + (options.controlTimeoutMs ?? 5_000);
   let buttonCount = await buttons.count();
   while (buttonCount === 0 && Date.now() < deadline) {
     await new Promise(resolveSleep => setTimeout(resolveSleep, 50));
     buttonCount = await buttons.count();
   }
+  // Some authenticated Temporary Chat variants expose connectors directly and
+  // do not render a personalization toggle. Connector discovery remains the
+  // authoritative pre-submit check on those surfaces.
+  if (buttonCount === 0) return;
   if (buttonCount !== 1) {
     throw new Error(`ChatGPT Temporary Chat exposed ${buttonCount} personalization controls`);
   }

--- a/tests/chatgpt-surface-resilience.test.ts
+++ b/tests/chatgpt-surface-resilience.test.ts
@@ -202,6 +202,19 @@ describe("ChatGPT Web surface resilience", () => {
     );
   });
 
+  test("continues when Temporary Chat exposes connectors without a personalization control", async () => {
+    const page = {
+      locator: () => ({
+        filter: () => ({ count: async () => 0 }),
+      }),
+    };
+
+    await expect(ensureChatGptTemporaryChatPersonalized(
+      page as never,
+      { controlTimeoutMs: 0 },
+    )).resolves.toBeUndefined();
+  });
+
   test("enables the personalized Temporary Chat mode required by connectors", async () => {
     let selectedMode = 1;
     let menuOpen = false;


### PR DESCRIPTION
## Problem

On the affected authenticated Temporary Chat surface, `v4.0.4-Enhanced.1` was no longer able to submit any prompt. Effort selection succeeded, but every attempt then failed before prompt insertion with:

`ChatGPT Temporary Chat exposed 0 personalization controls`

Diagnostics showed a visible authenticated composer and successful effort selection, while this current surface exposed the connectors directly and rendered no personalization control. This patch restored end-to-end operation on that surface.

## Fix

After the existing bounded discovery window, treat zero personalization controls as a supported surface variant and continue to the existing connector-selection path.

Submission safety remains fail-closed:

- multiple/ambiguous personalization controls still fail;
- when the control exists, the existing semantic mode validation is unchanged;
- exact `Codex Native2` discovery and selection still run before prompt insertion and Send, and remain the authoritative capability check.

## Validation

- Full suite: **1,144 passed, 1 platform skip, 0 failed** across 147 files.
- Focused regression and browser-worker suites: **107 passed, 0 failed**.
- TypeScript typecheck, bundle build, relocatable runtime smoke, and `git diff --check` passed.
- Live validation against the previously broken surface:
  - a simple connector turn completed (`WEB_OK`);
  - the connector menu opened and exact `Codex Native2` was selected;
  - the retained tab was reused for a subsequent research turn;
  - after Ctrl+C, the old physical browser turn ended and released before the follow-up surface started;
  - the immediate follow-up completed with one accepted submission;
  - no duplicate Send or overlapping browser work was observed.

This is intentionally a narrow compatibility fix with one regression test; it does not change the ownership or submission lifecycle.
