### PR TITLE
test: harden deterministic lifecycle gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,3 +113,20 @@ jobs:
           cache: false
       - name: Lint GitHub Actions
         run: go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 -config-file .github/actionlint.yaml .github/workflows/*.yml
+
+  ci-gate:
+    if: ${{ always() }}
+    needs: [lifecycle-sim, lifecycle-client-probe, verify, actionlint]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require every CI dependency to succeed
+        env:
+          LIFECYCLE_SIM_RESULT: ${{ needs['lifecycle-sim'].result }}
+          CLIENT_PROBE_RESULT: ${{ needs['lifecycle-client-probe'].result }}
+          VERIFY_RESULT: ${{ needs['verify'].result }}
+          ACTIONLINT_RESULT: ${{ needs['actionlint'].result }}
+        run: |
+          test "$LIFECYCLE_SIM_RESULT" = "success"
+          test "$CLIENT_PROBE_RESULT" = "success"
+          test "$VERIFY_RESULT" = "success"
+          test "$ACTIONLINT_RESULT" = "success"

--- a/.github/workflows/lifecycle-client-canary.yml
+++ b/.github/workflows/lifecycle-client-canary.yml
@@ -1,0 +1,105 @@
+name: Latest Lifecycle Client Canary
+
+on:
+  schedule:
+    - cron: "17 3 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  canary:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v6
+        timeout-minutes: 2
+      - uses: oven-sh/setup-bun@v2
+        timeout-minutes: 2
+        with:
+          bun-version: 1.4.0
+      - name: Record Bun version
+        id: bun
+        timeout-minutes: 1
+        run: echo "version=$(bun --version)" >> "$GITHUB_OUTPUT"
+      - name: Install project dependencies
+        timeout-minutes: 3
+        run: bun install --frozen-lockfile
+      - name: Install latest lifecycle clients
+        id: install
+        timeout-minutes: 3
+        shell: bash
+        run: |
+          client_root="$RUNNER_TEMP/lifecycle-clients"
+          mkdir -p "$client_root"
+          set +e
+          npm install --prefix "$client_root" --no-package-lock --no-audit --no-fund \
+            @openai/codex@latest @anthropic-ai/claude-code@latest
+          install_code=$?
+          set -e
+          if [ "$install_code" -eq 0 ]; then install_status=success; else install_status=failure; fi
+          codex_version=$(PACKAGE_PATH="$client_root/node_modules/@openai/codex/package.json" node -p 'require(process.env.PACKAGE_PATH).version' 2>/dev/null || echo unavailable)
+          claude_version=$(PACKAGE_PATH="$client_root/node_modules/@anthropic-ai/claude-code/package.json" node -p 'require(process.env.PACKAGE_PATH).version' 2>/dev/null || echo unavailable)
+          {
+            echo "status=$install_status"
+            echo "codex_version=$codex_version"
+            echo "claude_version=$claude_version"
+            echo "codex_path=$client_root/node_modules/.bin/codex"
+            echo "claude_path=$client_root/node_modules/.bin/claude"
+          } >> "$GITHUB_OUTPUT"
+      - name: Run latest Codex deterministic lane
+        id: codex
+        if: ${{ always() }}
+        timeout-minutes: 5
+        shell: bash
+        run: |
+          set +e
+          bun run lifecycle:sim --lane=codex --codex="${{ steps.install.outputs.codex_path }}"
+          lane_code=$?
+          if [ "$lane_code" -eq 0 ]; then lane_status=success; else lane_status=failure; fi
+          echo "status=$lane_status" >> "$GITHUB_OUTPUT"
+      - name: Run latest Claude deterministic lane
+        id: claude
+        if: ${{ always() }}
+        timeout-minutes: 5
+        shell: bash
+        run: |
+          set +e
+          bun run lifecycle:sim --lane=claude --claude="${{ steps.install.outputs.claude_path }}"
+          lane_code=$?
+          if [ "$lane_code" -eq 0 ]; then lane_status=success; else lane_status=failure; fi
+          echo "status=$lane_status" >> "$GITHUB_OUTPUT"
+      - name: Write privacy-safe canary report
+        if: ${{ always() }}
+        timeout-minutes: 1
+        env:
+          CANARY_INSTALL_STATUS: ${{ steps.install.outputs.status || 'failure' }}
+          CANARY_CODEX_STATUS: ${{ steps.codex.outputs.status || 'failure' }}
+          CANARY_CLAUDE_STATUS: ${{ steps.claude.outputs.status || 'failure' }}
+          CANARY_CODEX_VERSION: ${{ steps.install.outputs.codex_version || 'unavailable' }}
+          CANARY_CLAUDE_VERSION: ${{ steps.install.outputs.claude_version || 'unavailable' }}
+          CANARY_BUN_VERSION: ${{ steps.bun.outputs.version || 'unavailable' }}
+          CANARY_RUNNER: ${{ runner.os }}-${{ runner.arch }}
+        run: |
+          mkdir -p tmp/lifecycle-client-canary
+          node -e 'require("node:fs").writeFileSync("tmp/lifecycle-client-canary/report.json", JSON.stringify({commit:process.env.GITHUB_SHA,runner:process.env.CANARY_RUNNER,bun:process.env.CANARY_BUN_VERSION,clients:{codex:process.env.CANARY_CODEX_VERSION,claude:process.env.CANARY_CLAUDE_VERSION},status:{install:process.env.CANARY_INSTALL_STATUS,codex:process.env.CANARY_CODEX_STATUS,claude:process.env.CANARY_CLAUDE_STATUS},timestamp:new Date().toISOString()},null,2) + "\n")'
+      - name: Upload canary report
+        if: ${{ always() }}
+        timeout-minutes: 2
+        uses: actions/upload-artifact@v6
+        with:
+          name: latest-lifecycle-client-canary
+          path: tmp/lifecycle-client-canary/report.json
+          if-no-files-found: error
+      - name: Require installation and both lanes to pass
+        if: ${{ always() }}
+        timeout-minutes: 1
+        env:
+          CANARY_INSTALL_STATUS: ${{ steps.install.outputs.status || 'failure' }}
+          CANARY_CODEX_STATUS: ${{ steps.codex.outputs.status || 'failure' }}
+          CANARY_CLAUDE_STATUS: ${{ steps.claude.outputs.status || 'failure' }}
+        run: |
+          test "$CANARY_INSTALL_STATUS" = "success"
+          test "$CANARY_CODEX_STATUS" = "success"
+          test "$CANARY_CLAUDE_STATUS" = "success"

--- a/scripts/lifecycle-sim/codex-evidence.ts
+++ b/scripts/lifecycle-sim/codex-evidence.ts
@@ -1,3 +1,5 @@
+import { createHash } from "node:crypto";
+
 export type CodexLifecycleRole = "root" | "child" | "grandchild";
 
 export type CodexLifecycleRequestEvidence = {
@@ -6,9 +8,42 @@ export type CodexLifecycleRequestEvidence = {
   threadId?: string;
   agentName?: string;
   inputTypes: string[];
-  functionCalls: Array<{ callId: string; name: string; index: number }>;
-  functionOutputs: Array<{ callId: string; output: string; index: number }>;
+  functionCalls: Array<{ callId: string; name: string; argumentsDigest: string; index: number }>;
+  functionOutputs: Array<{ callId: string; outputDigest: string; index: number }>;
 };
+
+type HistoryEvent =
+  | { kind: "call"; callId: string; name: string; digest: string }
+  | { kind: "output"; callId: string; digest: string };
+
+export const digestLifecyclePayload = (value: string): string => (
+  createHash("sha256").update(value).digest("hex")
+);
+
+function orderedHistory(request: CodexLifecycleRequestEvidence): HistoryEvent[] {
+  return [
+    ...request.functionCalls.map(call => ({
+      kind: "call" as const,
+      callId: call.callId,
+      name: call.name,
+      digest: call.argumentsDigest,
+      index: call.index,
+    })),
+    ...request.functionOutputs.map(output => ({
+      kind: "output" as const,
+      callId: output.callId,
+      digest: output.outputDigest,
+      index: output.index,
+    })),
+  ].toSorted((left, right) => left.index - right.index)
+    .map(({ index: _index, ...event }) => event);
+}
+
+function assertAppendOnly(previous: HistoryEvent[], current: HistoryEvent[], role: CodexLifecycleRole): void {
+  if (previous.some((event, index) => JSON.stringify(event) !== JSON.stringify(current[index]))) {
+    throw new Error(`${role} violated append-only history`);
+  }
+}
 
 const v2AgentNames: Record<CodexLifecycleRole, string> = {
   root: "/root",
@@ -33,6 +68,7 @@ export function assertCodexLifecycleRequests(
   protocol: "v1" | "v2",
 ): void {
   const threads = new Map<CodexLifecycleRole, string>();
+  const histories = new Map<CodexLifecycleRole, HistoryEvent[]>();
   for (const request of requests) {
     if (!expectedSteps[request.role].includes(request.step)) {
       throw new Error(`${request.role} did not follow exact lifecycle steps: unexpected ${request.step}`);
@@ -51,6 +87,11 @@ export function assertCodexLifecycleRequests(
       throw new Error(`${request.role}:${request.step} has duplicate function call IDs`);
     }
     const resultIds = new Set<string>();
+    for (const call of request.functionCalls) {
+      if (!/^[a-f0-9]{64}$/.test(call.argumentsDigest)) {
+        throw new Error(`${request.role}:${request.step} has invalid function-call arguments digest`);
+      }
+    }
     for (const result of request.functionOutputs) {
       if (resultIds.has(result.callId)) {
         throw new Error(`${request.role}:${request.step} has duplicate results for call ID ${result.callId}`);
@@ -60,6 +101,9 @@ export function assertCodexLifecycleRequests(
       if (!call) throw new Error(`${request.role}:${request.step} has an unknown result call ID ${result.callId}`);
       if (call.index >= result.index) {
         throw new Error(`${request.role}:${request.step} has reversed function-call ordering for ${result.callId}`);
+      }
+      if (!/^[a-f0-9]{64}$/.test(result.outputDigest)) {
+        throw new Error(`${request.role}:${request.step} has invalid function output digest`);
       }
     }
     if (request.functionCalls.length !== request.functionOutputs.length) {
@@ -77,6 +121,9 @@ export function assertCodexLifecycleRequests(
       || names.some((name, index) => name !== expectedNames[index])) {
       throw new Error(`${request.role}:${request.step} used unexpected tool history: ${JSON.stringify(names)}`);
     }
+    const history = orderedHistory(request);
+    assertAppendOnly(histories.get(request.role) ?? [], history, request.role);
+    histories.set(request.role, history);
   }
   const owners = [...threads.values()];
   if (new Set(owners).size !== owners.length) throw new Error("nested roles reused a thread owner");

--- a/scripts/lifecycle-sim/manifest.ts
+++ b/scripts/lifecycle-sim/manifest.ts
@@ -1,0 +1,22 @@
+export const codexLifecycleTests = [
+  "tests/native-steering-boundary.test.ts",
+  "tests/local-compaction-release.test.ts",
+  "tests/subagent-environment-inheritance.test.ts",
+] as const;
+
+export const claudeLifecycleTests = [
+  "tests/claude-compact-agents.test.ts",
+  "tests/claude-steering-replay.test.ts",
+  "tests/claude-session-abort.test.ts",
+] as const;
+
+export const sharedLifecycleTests = [
+  "tests/server-adapter-injection.test.ts",
+  "tests/server-compaction.test.ts",
+  "tests/retained-compaction-handoff.test.ts",
+  "tests/turn-broker-lifecycle.test.ts",
+  "tests/lifecycle-sim-evidence.test.ts",
+  "tests/lifecycle-sim-codex-evidence.test.ts",
+  "tests/lifecycle-sim-production-composition.test.ts",
+  "tests/lifecycle-race-ordering.test.ts",
+] as const;

--- a/scripts/lifecycle-sim/run.ts
+++ b/scripts/lifecycle-sim/run.ts
@@ -1,5 +1,6 @@
 import { resolveLifecycleExecutable } from "../lifecycle-smoke/paths";
 import { resolve } from "node:path";
+import { claudeLifecycleTests, codexLifecycleTests, sharedLifecycleTests } from "./manifest";
 
 type Lane = "codex" | "claude" | "all";
 
@@ -19,7 +20,7 @@ async function run(args: string[], cwd = repo): Promise<void> {
   if (code !== 0) throw new Error(`Lifecycle command exited ${code}: ${args.slice(1).join(" ")}`);
 }
 
-async function runTests(files: string[]): Promise<void> {
+async function runTests(files: readonly string[]): Promise<void> {
   await run([process.execPath, "test", ...files.map(file => file.replace(/^tests[\\/]/, ""))], resolve(repo, "tests"));
 }
 
@@ -28,36 +29,19 @@ async function codexLane(): Promise<void> {
   await run([process.execPath, "run", "scripts/smoke-codex-subagents.ts", "--v1", codex]);
   await run([process.execPath, "run", "scripts/smoke-codex-subagents.ts", "--v2", codex]);
   await run([process.execPath, "run", "scripts/smoke-codex-cancel.ts", codex]);
-  await runTests([
-    "tests/native-steering-boundary.test.ts",
-    "tests/local-compaction-release.test.ts",
-    "tests/subagent-environment-inheritance.test.ts",
-  ]);
+  await runTests(codexLifecycleTests);
   process.stdout.write("CODEX_DETERMINISTIC_LIFECYCLE_LANE_OK\n");
 }
 
 async function claudeLane(): Promise<void> {
   await run([process.execPath, "run", "scripts/lifecycle-sim/claude.ts", `--claude=${executable("claude")}`]);
-  await runTests([
-    "tests/claude-compact-agents.test.ts",
-    "tests/claude-steering-replay.test.ts",
-    "tests/claude-session-abort.test.ts",
-  ]);
+  await runTests(claudeLifecycleTests);
   process.stdout.write("CLAUDE_DETERMINISTIC_LIFECYCLE_LANE_OK\n");
 }
 
 if (lane === "codex" || lane === "all") await codexLane();
 if (lane === "claude" || lane === "all") await claudeLane();
 if (lane === "all") {
-  await runTests([
-    "tests/server-adapter-injection.test.ts",
-    "tests/server-compaction.test.ts",
-    "tests/retained-compaction-handoff.test.ts",
-    "tests/turn-broker-lifecycle.test.ts",
-    "tests/lifecycle-sim-evidence.test.ts",
-    "tests/lifecycle-sim-codex-evidence.test.ts",
-    "tests/lifecycle-sim-production-composition.test.ts",
-    "tests/lifecycle-race-ordering.test.ts",
-  ]);
+  await runTests(sharedLifecycleTests);
   process.stdout.write("ALL_DETERMINISTIC_LIFECYCLE_LANES_OK\n");
 }

--- a/scripts/smoke-codex-subagents.ts
+++ b/scripts/smoke-codex-subagents.ts
@@ -6,7 +6,7 @@ import { bridgeToResponsesSSE } from "../src/bridge";
 import { defaultConfig } from "../src/config";
 import { augmentNativeModelCatalog } from "../src/model-catalog";
 import type { AdapterEvent } from "../src/types";
-import { assertCodexLifecycleRequests } from "./lifecycle-sim/codex-evidence";
+import { assertCodexLifecycleRequests, digestLifecyclePayload } from "./lifecycle-sim/codex-evidence";
 
 const protocol = process.argv.includes("--v1") ? "v1" : "v2";
 const explicitChildModel = "gpt-5.6-sol";
@@ -49,8 +49,8 @@ const requestLog: Array<{
   model?: string;
   reasoningEffort?: string;
   inputTypes: string[];
-  functionCalls: Array<{ callId: string; name: string; index: number }>;
-  functionOutputs: Array<{ callId: string; output: string; index: number }>;
+  functionCalls: Array<{ callId: string; name: string; argumentsDigest: string; index: number }>;
+  functionOutputs: Array<{ callId: string; outputDigest: string; index: number }>;
   encryptedContent: boolean;
 }> = [];
 
@@ -272,9 +272,11 @@ const server = Bun.serve({
             && (item as { type?: unknown }).type === "function_call"
             && typeof (item as { call_id?: unknown }).call_id === "string"
             && typeof (item as { name?: unknown }).name === "string"
+            && typeof (item as { arguments?: unknown }).arguments === "string"
             ? [{
               callId: String((item as { call_id: string }).call_id),
               name: String((item as { name: string }).name),
+              argumentsDigest: digestLifecyclePayload(String((item as { arguments: string }).arguments)),
               index,
             }]
             : [])
@@ -286,7 +288,7 @@ const server = Bun.serve({
             && typeof (item as { output?: unknown }).output === "string"
             ? [{
               callId: String((item as { call_id: string }).call_id),
-              output: String((item as { output: string }).output).slice(0, 500),
+              outputDigest: digestLifecyclePayload(String((item as { output: string }).output)),
               index,
             }]
             : [])

--- a/tests/lifecycle-profiles.test.ts
+++ b/tests/lifecycle-profiles.test.ts
@@ -31,6 +31,16 @@ test("CI runs deterministic lifecycle simulation and never calls a live profile"
   expect(workflow).toContain("turn-broker-lifecycle.test.ts");
 });
 
+test("CI exposes one fail-closed aggregate gate for branch protection", () => {
+  const workflow = readFileSync(resolve(repo, ".github", "workflows", "ci.yml"), "utf8");
+  expect(workflow).toMatch(/ci-gate:\s+if: \$\{\{ always\(\) \}\}/);
+  expect(workflow).toContain("needs: [lifecycle-sim, lifecycle-client-probe, verify, actionlint]");
+  for (const dependency of ["lifecycle-sim", "lifecycle-client-probe", "verify", "actionlint"]) {
+    expect(workflow).toContain(`needs['${dependency}'].result`);
+  }
+  expect(workflow).toContain('test "$LIFECYCLE_SIM_RESULT" = "success"');
+});
+
 test("the executable manifest owns every deterministic lifecycle test", () => {
   expect(codexLifecycleTests).toContain("tests/native-steering-boundary.test.ts");
   expect(claudeLifecycleTests).toContain("tests/claude-session-abort.test.ts");

--- a/tests/lifecycle-profiles.test.ts
+++ b/tests/lifecycle-profiles.test.ts
@@ -79,3 +79,34 @@ test("release builds rerun the deterministic lifecycle gate at the tag SHA", () 
   expect(workflow).toContain("@anthropic-ai/claude-code@2.1.251");
   expect(workflow).toMatch(/build:\s+needs: lifecycle-gate/);
 });
+
+test("latest-client canary runs both offline lanes and always reports safe status", () => {
+  const workflow = readFileSync(resolve(repo, ".github", "workflows", "lifecycle-client-canary.yml"), "utf8");
+  expect(workflow).toContain('cron: "17 3 * * 1"');
+  expect(workflow).toContain("workflow_dispatch:");
+  expect(workflow).toMatch(/permissions:\s+contents: read/);
+  expect(workflow).toContain("@openai/codex@latest");
+  expect(workflow).toContain("@anthropic-ai/claude-code@latest");
+  expect(workflow).toContain("timeout-minutes: 25");
+  for (const [step, timeout] of [
+    ["Install project dependencies", 3],
+    ["Install latest lifecycle clients", 3],
+    ["Run latest Codex deterministic lane", 5],
+    ["Run latest Claude deterministic lane", 5],
+  ] as const) {
+    const block = workflow.slice(workflow.indexOf(step), workflow.indexOf("\n      - name:", workflow.indexOf(step) + 1));
+    expect(block).toContain(`timeout-minutes: ${timeout}`);
+  }
+  expect(workflow).toContain("lifecycle:sim --lane=codex");
+  expect(workflow).toContain("lifecycle:sim --lane=claude");
+  expect(workflow.match(/if: \$\{\{ always\(\) \}\}/g)).toHaveLength(5);
+  expect(workflow).toContain("actions/upload-artifact@v6");
+  expect(workflow).toContain("CANARY_INSTALL_STATUS");
+  const reportStep = workflow.slice(
+    workflow.indexOf("Write privacy-safe canary report"),
+    workflow.indexOf("Upload canary report"),
+  );
+  expect(reportStep).toContain("node -e");
+  expect(reportStep).not.toContain("bun -e");
+  expect(workflow).not.toMatch(/secret|smoke:lifecycle:web|smoke:lifecycle:deep/i);
+});

--- a/tests/lifecycle-profiles.test.ts
+++ b/tests/lifecycle-profiles.test.ts
@@ -1,6 +1,11 @@
 import { expect, test } from "bun:test";
-import { readFileSync } from "node:fs";
+import { readFileSync, readdirSync } from "node:fs";
 import { resolve } from "node:path";
+import {
+  claudeLifecycleTests,
+  codexLifecycleTests,
+  sharedLifecycleTests,
+} from "../scripts/lifecycle-sim/manifest";
 
 const repo = resolve(import.meta.dir, "..");
 
@@ -26,12 +31,15 @@ test("CI runs deterministic lifecycle simulation and never calls a live profile"
   expect(workflow).toContain("turn-broker-lifecycle.test.ts");
 });
 
-test("the all lane runs both lifecycle evidence oracle suites", () => {
-  const runner = readFileSync(resolve(repo, "scripts", "lifecycle-sim", "run.ts"), "utf8");
-  expect(runner).toContain("tests/lifecycle-sim-evidence.test.ts");
-  expect(runner).toContain("tests/lifecycle-sim-codex-evidence.test.ts");
-  expect(runner).toContain("tests/lifecycle-sim-production-composition.test.ts");
-  expect(runner).toContain("tests/lifecycle-race-ordering.test.ts");
+test("the executable manifest owns every deterministic lifecycle test", () => {
+  expect(codexLifecycleTests).toContain("tests/native-steering-boundary.test.ts");
+  expect(claudeLifecycleTests).toContain("tests/claude-session-abort.test.ts");
+  expect(sharedLifecycleTests).toContain("tests/lifecycle-race-ordering.test.ts");
+  const registered = new Set<string>([...codexLifecycleTests, ...claudeLifecycleTests, ...sharedLifecycleTests]);
+  const lifecycleSimTests = readdirSync(resolve(repo, "tests"))
+    .filter(name => /^lifecycle-sim-.*\.test\.ts$/.test(name))
+    .map(name => `tests/${name}`);
+  expect(lifecycleSimTests.every(file => registered.has(file))).toBe(true);
 });
 
 test("the Codex lane covers compatibility V1 and native V2 clients", () => {

--- a/tests/lifecycle-sim-codex-evidence.test.ts
+++ b/tests/lifecycle-sim-codex-evidence.test.ts
@@ -1,106 +1,101 @@
 import { describe, expect, test } from "bun:test";
-import { assertCodexLifecycleRequests } from "../scripts/lifecycle-sim/codex-evidence";
+import {
+  assertCodexLifecycleRequests,
+  digestLifecyclePayload as digest,
+} from "../scripts/lifecycle-sim/codex-evidence";
 
-const request = (
-  role: "root" | "child" | "grandchild",
-  step: number,
-  threadId: string,
-  agentName: string,
-  inputTypes: string[] = ["message"],
-  functionCalls: Array<{ callId: string; name: string; index: number }> = [],
-  functionOutputs: Array<{ callId: string; output: string; index: number }> = [],
-) => ({ role, step, threadId, agentName, inputTypes, functionCalls, functionOutputs });
+type Role = "root" | "child" | "grandchild";
+type Call = { callId: string; name: string; argumentsDigest: string; index: number };
+type Output = { callId: string; outputDigest: string; index: number };
+
+const names = {
+  root: ["spawn_agent", "wait_agent", "followup_task", "wait_agent"],
+  child: ["spawn_agent", "wait_agent"],
+  grandchild: [],
+} satisfies Record<Role, string[]>;
+const steps = { root: 5, child: 4, grandchild: 1 } satisfies Record<Role, number>;
+const agents = {
+  root: "/root",
+  child: "/root/lifecycle_child",
+  grandchild: "/root/lifecycle_child/lifecycle_grandchild",
+} satisfies Record<Role, string>;
+
+function evidence() {
+  return (Object.keys(steps) as Role[]).flatMap(role => (
+    Array.from({ length: steps[role] }, (_, step) => {
+      const count = role === "root" ? step : role === "child" ? Math.min(step, 2) : 0;
+      const offset = step % 2;
+      const functionCalls: Call[] = names[role].slice(0, count).map((name, index) => ({
+        callId: `${role}-${index}`,
+        name,
+        argumentsDigest: digest(`${role}-arguments-${index}`),
+        index: offset + index * 2,
+      }));
+      const functionOutputs: Output[] = functionCalls.map((call, index) => ({
+        callId: call.callId,
+        outputDigest: digest(`${role}-output-${index}`),
+        index: offset + index * 2 + 1,
+      }));
+      return {
+        role,
+        step,
+        threadId: `${role}-thread`,
+        agentName: agents[role],
+        inputTypes: [],
+        functionCalls,
+        functionOutputs,
+      };
+    })
+  ));
+}
+
+function validate(values = evidence()) {
+  assertCodexLifecycleRequests(values, "v2");
+}
 
 describe("Codex deterministic lifecycle request evidence", () => {
-  test("accepts stable distinct nested ownership and ordered tool results", () => {
-    const values = [
-      request("root", 0, "root-thread", "/root"),
-      request("root", 1, "root-thread", "/root", ["message", "function_call", "function_call_output"],
-        [{ callId: "root-spawn", name: "spawn_agent", index: 1 }],
-        [{ callId: "root-spawn", output: "spawn", index: 2 }]),
-      request("root", 2, "root-thread", "/root", ["function_call", "function_call_output", "function_call", "function_call_output"],
-        [
-          { callId: "root-spawn", name: "spawn_agent", index: 0 },
-          { callId: "root-wait", name: "wait_agent", index: 2 },
-        ], [
-          { callId: "root-spawn", output: "spawn", index: 1 },
-          { callId: "root-wait", output: "wait", index: 3 },
-        ]),
-      request("root", 3, "root-thread", "/root", ["function_call", "function_call_output", "function_call", "function_call_output", "function_call", "function_call_output"],
-        [
-          { callId: "root-spawn", name: "spawn_agent", index: 0 },
-          { callId: "root-wait", name: "wait_agent", index: 2 },
-          { callId: "root-followup", name: "followup_task", index: 4 },
-        ], [
-          { callId: "root-spawn", output: "spawn", index: 1 },
-          { callId: "root-wait", output: "wait", index: 3 },
-          { callId: "root-followup", output: "followup", index: 5 },
-        ]),
-      request("root", 4, "root-thread", "/root", ["function_call", "function_call_output", "function_call", "function_call_output", "function_call", "function_call_output", "function_call", "function_call_output"],
-        [
-          { callId: "root-spawn", name: "spawn_agent", index: 0 },
-          { callId: "root-wait", name: "wait_agent", index: 2 },
-          { callId: "root-followup", name: "followup_task", index: 4 },
-          { callId: "root-wait-2", name: "wait_agent", index: 6 },
-        ], [
-          { callId: "root-spawn", output: "spawn", index: 1 },
-          { callId: "root-wait", output: "wait", index: 3 },
-          { callId: "root-followup", output: "followup", index: 5 },
-          { callId: "root-wait-2", output: "wait", index: 7 },
-        ]),
-      request("child", 0, "child-thread", "/root/lifecycle_child"),
-      request("child", 1, "child-thread", "/root/lifecycle_child", ["agent_message", "function_call", "function_call_output"],
-        [{ callId: "child-spawn", name: "spawn_agent", index: 1 }],
-        [{ callId: "child-spawn", output: "spawn", index: 2 }]),
-      request("child", 2, "child-thread", "/root/lifecycle_child", ["function_call", "function_call_output", "function_call", "function_call_output"],
-        [
-          { callId: "child-spawn", name: "spawn_agent", index: 0 },
-          { callId: "child-wait", name: "wait_agent", index: 2 },
-        ], [
-          { callId: "child-spawn", output: "spawn", index: 1 },
-          { callId: "child-wait", output: "wait", index: 3 },
-        ]),
-      request("child", 3, "child-thread", "/root/lifecycle_child", ["function_call", "function_call_output", "function_call", "function_call_output"],
-        [
-          { callId: "child-spawn", name: "spawn_agent", index: 0 },
-          { callId: "child-wait", name: "wait_agent", index: 2 },
-        ], [
-          { callId: "child-spawn", output: "spawn", index: 1 },
-          { callId: "child-wait", output: "wait", index: 3 },
-        ]),
-      request("grandchild", 0, "grandchild-thread", "/root/lifecycle_child/lifecycle_grandchild"),
-    ];
-    expect(() => assertCodexLifecycleRequests(values, "v2")).not.toThrow();
+  test("accepts append-only history despite shifted absolute input indexes", () => {
+    expect(validate).not.toThrow();
   });
 
-  test("rejects cross-role thread reuse, missing results, and reversed ordering", () => {
-    expect(() => assertCodexLifecycleRequests([
-      request("root", 0, "shared", "/root"),
-      request("child", 0, "shared", "/root/lifecycle_child"),
-      request("child", 1, "shared", "/root/lifecycle_child", ["function_call_output", "function_call"],
-        [{ callId: "call", name: "spawn_agent", index: 1 }],
-        [{ callId: "wrong", output: "result", index: 0 }]),
-    ], "v2")).toThrow(/thread|tool result|ordering|call id/i);
+  test.each([
+    ["call ID rewrite", (values: ReturnType<typeof evidence>) => {
+      values[2]!.functionCalls[0]!.callId = "rewritten";
+      values[2]!.functionOutputs[0]!.callId = "rewritten";
+    }],
+    ["arguments rewrite", (values: ReturnType<typeof evidence>) => {
+      values[2]!.functionCalls[0]!.argumentsDigest = digest("rewritten arguments");
+    }],
+    ["output rewrite", (values: ReturnType<typeof evidence>) => {
+      values[2]!.functionOutputs[0]!.outputDigest = digest("rewritten output");
+    }],
+    ["historical call and result replacement", (values: ReturnType<typeof evidence>) => {
+      values[3]!.functionCalls[1]!.callId = "replacement";
+      values[3]!.functionOutputs[1]!.callId = "replacement";
+    }],
+    ["result reordering", (values: ReturnType<typeof evidence>) => {
+      values[3]!.functionCalls[1]!.index = 1;
+      values[3]!.functionOutputs[0]!.index = 3;
+      values[3]!.functionOutputs[1]!.index = 2;
+    }],
+    ["child step 3 drops step 2 history", (values: ReturnType<typeof evidence>) => {
+      const childStep3 = values.find(value => value.role === "child" && value.step === 3)!;
+      childStep3.functionCalls[0]!.callId = "new-child-call";
+      childStep3.functionOutputs[0]!.callId = "new-child-call";
+    }],
+  ])("rejects %s across adjacent requests", (_label, mutate) => {
+    const values = evidence();
+    mutate(values);
+    expect(() => validate(values)).toThrow(/append-only history/i);
   });
 
-  test("rejects extra rounds, duplicate results, and mismatched call ids", () => {
-    const base = request("root", 0, "root-thread", "/root");
-    expect(() => assertCodexLifecycleRequests([base, { ...base, step: 5 }], "v2"))
-      .toThrow(/exact lifecycle steps/i);
-    expect(() => assertCodexLifecycleRequests([
-      request("root", 0, "root-thread", "/root"),
-      request("root", 1, "root-thread", "/root", ["function_call", "function_call_output", "function_call_output"],
-        [{ callId: "spawn", name: "spawn_agent", index: 0 }],
-        [
-          { callId: "spawn", output: "one", index: 1 },
-          { callId: "spawn", output: "two", index: 2 },
-        ]),
-    ], "v2")).toThrow(/duplicate|exact/i);
-    expect(() => assertCodexLifecycleRequests([
-      request("root", 0, "root-thread", "/root"),
-      request("root", 1, "root-thread", "/root", ["function_call", "function_call_output"],
-        [{ callId: "spawn", name: "spawn_agent", index: 0 }],
-        [{ callId: "other", output: "one", index: 1 }]),
-    ], "v2")).toThrow(/call id/i);
+  test("rejects duplicate results and cross-role thread reuse", () => {
+    const duplicate = evidence();
+    duplicate[1]!.functionOutputs.push({ ...duplicate[1]!.functionOutputs[0]!, index: 99 });
+    expect(() => validate(duplicate)).toThrow(/duplicate|exact/i);
+
+    const reused = evidence();
+    reused.find(value => value.role === "child")!.threadId = "root-thread";
+    expect(() => validate(reused)).toThrow(/thread/i);
   });
 });

--- a/tests/lifecycle-sim-production-composition.test.ts
+++ b/tests/lifecycle-sim-production-composition.test.ts
@@ -3,6 +3,7 @@ import { mkdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { BrowserTurn } from "../src/adapters/chatgpt-web/browser-worker";
+import type { ChatGptRuntimeWorker } from "../src/adapters/chatgpt-web/adapter-runtime-factory";
 import { createChatGptWebAdapter } from "../src/adapters/chatgpt-web/index";
 import { callTurnBroker, type BrokerToolResult } from "../src/adapters/chatgpt-web/turn-broker";
 import { chatGptTurnSessions } from "../src/adapters/chatgpt-web/turn-execution";
@@ -11,6 +12,59 @@ import { SUMMARY_PREFIX } from "../src/responses/compaction";
 import { startServer } from "../src/server";
 
 const jsonHeaders = { "content-type": "application/json" };
+
+type SseCapture = {
+  events: Array<Record<string, unknown>>;
+  doneCount: number;
+  completed: Record<string, unknown>;
+};
+
+async function captureSse(response: Response): Promise<SseCapture> {
+  expect(response.status).toBe(200);
+  const payloads = (await response.text()).split(/\r?\n/)
+    .filter(line => line.startsWith("data: "))
+    .map(line => line.slice(6));
+  const doneCount = payloads.filter(payload => payload === "[DONE]").length;
+  const events = payloads.filter(payload => payload !== "[DONE]")
+    .map(payload => JSON.parse(payload) as Record<string, unknown>);
+  const completedIndexes = events.flatMap((event, index) => event.type === "response.completed" ? [index] : []);
+  expect(completedIndexes).toHaveLength(1);
+  expect(doneCount).toBe(1);
+  expect(payloads.at(-1)).toBe("[DONE]");
+  expect(events.slice(completedIndexes[0]! + 1)).toHaveLength(0);
+  return { events, doneCount, completed: events[completedIndexes[0]!]! };
+}
+
+function completedItems(capture: SseCapture): Array<Record<string, unknown>> {
+  const response = capture.completed.response as Record<string, unknown>;
+  return response.output as Array<Record<string, unknown>>;
+}
+
+function terminalItems(capture: SseCapture, type: string): Array<Record<string, unknown>> {
+  return capture.events.flatMap(event => (
+    event.type === "response.output_item.done"
+      && (event.item as Record<string, unknown> | undefined)?.type === type
+      ? [event.item as Record<string, unknown>]
+      : []
+  ));
+}
+
+function startProductionServer(
+  config: ReturnType<typeof defaultConfig>,
+  root: string,
+  worker: ChatGptRuntimeWorker,
+) {
+  return startServer(config, {
+    adapterFactory: provider => createChatGptWebAdapter({
+      ...provider,
+      chatgptWeb: {
+        ...provider.chatgptWeb,
+        threadEnvironmentStatePath: join(root, "thread-environments.json"),
+        lunaCheckpointStatePath: join(root, "luna-checkpoints.json"),
+      },
+    }, { worker }),
+  });
+}
 
 test("the deterministic lane composes production routing, adapter, broker, compact, and cancellation", async () => {
   const root = join(tmpdir(), `cgw-production-lifecycle-${process.pid}-${Date.now()}`);
@@ -66,16 +120,7 @@ test("the deterministic lane composes production routing, adapter, broker, compa
     },
     requestPreemptiveRetry: () => false,
   };
-  const server = startServer(config, {
-    adapterFactory: provider => createChatGptWebAdapter({
-      ...provider,
-      chatgptWeb: {
-        ...provider.chatgptWeb,
-        threadEnvironmentStatePath: join(root, "thread-environments.json"),
-        lunaCheckpointStatePath: join(root, "luna-checkpoints.json"),
-      },
-    }, { worker }),
-  });
+  const server = startProductionServer(config, root, worker);
   const endpoint = `http://127.0.0.1:${server.port}`;
   const environment = `<environment_context><cwd>${root}</cwd><workspace_roots><root>${root}</root></workspace_roots><permission_profile type="disabled"><file_system type="unrestricted" /></permission_profile></environment_context>`;
   const metadata = { "x-codex-turn-metadata": JSON.stringify({ thread_id: "production-thread", turn_id: "production-turn" }) };
@@ -147,6 +192,139 @@ test("the deterministic lane composes production routing, adapter, broker, compa
     await cancelled;
     for (let attempt = 0; attempt < 50 && chatGptTurnSessions.activeCount() > 0; attempt += 1) await Bun.sleep(10);
     const health = await fetch(`${endpoint}/healthz`).then(response => response.json()) as Record<string, unknown>;
+    expect(health).toMatchObject({ active_http_turns: 0, active_browser_turns: 0 });
+    expect(chatGptTurnSessions.activeCount()).toBe(0);
+  } finally {
+    chatGptTurnSessions.clear();
+    await server.stop(true);
+    rmSync(root, { recursive: true, force: true });
+  }
+}, 20_000);
+
+test("Enhanced streaming retains one production surface and fully cleans an aborted continuation", async () => {
+  const root = join(tmpdir(), `cgw-production-enhanced-stream-${process.pid}-${Date.now()}`);
+  mkdirSync(root, { recursive: true });
+  const config = defaultConfig("full");
+  config.port = 0;
+  config.proAvailable = true;
+  config.useEnhancedWebSessionMode = true;
+  config.brokerSocketPath = defaultBrokerEndpoint(root);
+  const turns: Array<Pick<BrowserTurn, "retainConversation" | "conversationKey">> = [];
+  const surfaces = new Set<string>();
+  const tokens: string[] = [];
+  let cancellationStarted!: () => void;
+  const cancellationReady = new Promise<void>(resolve => { cancellationStarted = resolve; });
+  const worker = {
+    async run(turn: BrowserTurn): Promise<string> {
+      turns.push({ retainConversation: turn.retainConversation, conversationKey: turn.conversationKey });
+      if (!turn.conversationKey) throw new Error("Enhanced turn has no conversation key");
+      surfaces.add(turn.conversationKey);
+      const prepared = await turn.prepare();
+      try {
+        turn.onSendActivated?.();
+        turn.onSubmitted?.();
+        if (prepared.text.includes("ENHANCED_STREAM_CANCEL")) {
+          cancellationStarted();
+          await new Promise<void>((_resolve, reject) => {
+            const fail = () => reject(turn.abortSignal?.reason ?? new DOMException("aborted", "AbortError"));
+            if (turn.abortSignal?.aborted) fail();
+            else turn.abortSignal?.addEventListener("abort", fail, { once: true });
+          });
+        }
+        const token = prepared.text.match(/turn_token (turn_[A-Za-z0-9_-]+)/)?.[1];
+        if (!token) throw new Error("Enhanced streaming tool turn has no broker token");
+        tokens.push(token);
+        const claimed = await callTurnBroker<{ bindingId: string }>(
+          config.brokerSocketPath,
+          { method: "claim", token },
+        );
+        const result = await callTurnBroker<BrokerToolResult>(config.brokerSocketPath, {
+          method: "invoke",
+          bindingId: claimed.bindingId,
+          wireName: "exec_command",
+          freeform: false,
+          arguments: { cmd: "echo enhanced-stream" },
+        }, 10_000);
+        expect(result.isError).not.toBe(true);
+        const answer = "ENHANCED_STREAM_OK";
+        turn.onTextDelta(answer);
+        return answer;
+      } finally {
+        prepared.release();
+      }
+    },
+    requestPreemptiveRetry: () => false,
+  };
+  const server = startProductionServer(config, root, worker);
+  const endpoint = `http://127.0.0.1:${server.port}`;
+  const environment = `<environment_context><cwd>${root}</cwd><workspace_roots><root>${root}</root></workspace_roots><permission_profile type="disabled"><file_system type="unrestricted" /></permission_profile></environment_context>`;
+  const message = (text: string, turnId: string, role = "user") => ({
+    type: "message",
+    role,
+    content: [{ type: role === "assistant" ? "output_text" : "input_text", text }],
+    internal_chat_message_metadata_passthrough: { turn_id: turnId },
+  });
+  const initialInput = [message(environment, "enhanced-turn"), message("Run ENHANCED_STREAM_TOOL.", "enhanced-turn")];
+  const requestBody = {
+    model: "chatgpt-web/high",
+    stream: true,
+    input: initialInput,
+    tools: [{ type: "function", name: "exec_command", description: "Run a command", parameters: { type: "object" } }],
+    prompt_cache_key: "enhanced-thread",
+    client_metadata: { "x-codex-turn-metadata": JSON.stringify({ thread_id: "enhanced-thread", turn_id: "enhanced-turn" }) },
+  };
+  const post = (body: unknown, signal?: AbortSignal) => fetch(`${endpoint}/v1/responses`, {
+    method: "POST",
+    headers: jsonHeaders,
+    body: JSON.stringify(body),
+    ...(signal ? { signal } : {}),
+  });
+
+  try {
+    const first = await captureSse(await post(requestBody));
+    const firstCalls = completedItems(first).filter(item => item.type === "function_call");
+    expect(firstCalls).toHaveLength(1);
+    expect(terminalItems(first, "function_call")).toHaveLength(1);
+    const call = firstCalls[0]!;
+
+    const second = await captureSse(await post({
+      ...requestBody,
+      input: [...initialInput, call, {
+        type: "function_call_output",
+        call_id: call.call_id,
+        output: JSON.stringify({ output: "enhanced-stream", exit_code: 0 }),
+      }],
+    }));
+    expect(completedItems(second).filter(item => item.type === "message")).toHaveLength(1);
+    expect(terminalItems(second, "message")).toHaveLength(1);
+    expect(turns).toHaveLength(1);
+    expect(turns[0]).toMatchObject({ retainConversation: true });
+    expect(turns[0]!.conversationKey).toMatch(/^[a-f0-9]{64}$/);
+    expect(surfaces.size).toBe(1);
+    await expect(callTurnBroker(config.brokerSocketPath, { method: "claim", token: tokens[0] }))
+      .rejects.toThrow(/finished|retired|invalid|expired/i);
+
+    const cancelTurnId = "enhanced-cancel";
+    const cancelInput = [
+      ...initialInput,
+      call,
+      { type: "function_call_output", call_id: call.call_id, output: "enhanced-stream" },
+      message("ENHANCED_STREAM_OK", "enhanced-turn", "assistant"),
+      message("ENHANCED_STREAM_CANCEL", cancelTurnId),
+    ];
+    const controller = new AbortController();
+    const cancelled = post({
+      ...requestBody,
+      input: cancelInput,
+      client_metadata: { "x-codex-turn-metadata": JSON.stringify({ thread_id: "enhanced-thread", turn_id: cancelTurnId }) },
+    }, controller.signal).then(response => response.text()).catch(error => error);
+    await cancellationReady;
+    controller.abort();
+    await cancelled;
+    for (let attempt = 0; attempt < 50 && chatGptTurnSessions.activeCount() > 0; attempt += 1) await Bun.sleep(10);
+    const health = await fetch(`${endpoint}/healthz`).then(response => response.json()) as Record<string, unknown>;
+    expect(turns.at(-1)?.conversationKey).toBe(turns[0]!.conversationKey);
+    expect(surfaces.size).toBe(1);
     expect(health).toMatchObject({ active_http_turns: 0, active_browser_turns: 0 });
     expect(chatGptTurnSessions.activeCount()).toBe(0);
   } finally {


### PR DESCRIPTION
## Summary
- hash full deterministic Codex call/result payloads and enforce per-role append-only history across adjacent requests
- cover production Enhanced streaming, retained continuation, SSE terminal uniqueness, cancellation, and full idle cleanup
- make the lifecycle test manifest executable and completeness-checked
- add a fail-closed aggregate `ci-gate` for branch protection
- add a bounded weekly/manual latest-client canary with privacy-safe status artifacts

## Validation
- Codex V1 and V2 deterministic lanes: passed
- Claude deterministic lane: passed
- `lifecycle:sim --lane=all`: passed
- bounded root suite: 131 files passed
- root TypeScript typecheck: passed
- workflow contract and Bun pin tests: passed
- actionlint: passed
- local latest clients: Codex 0.151.0 and Claude 2.1.252 both passed
- two fresh targeted reviews completed; validated canary failure-path findings were fixed

## Release decision
DLT-02 and the latest-client preflight found no production runtime/server/launcher defect. This PR therefore keeps version `4.0.7-Enhanced.2` and does not create an Enhanced.3 release.