### PR TITLE
fix: restore effort selection after ChatGPT picker redesign

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -25,7 +25,7 @@
 この独立管理の **Enhanced** fork は上流リリースを追跡し、長時間実行する Codex／Claude Code
 タスク向けの Web セッションライフサイクルを追加します。fork のバージョンは
 `<upstream>-Enhanced.<revision>` 形式で、`3.0.1-Enhanced.1` から始まりました。
-現在のバージョンは上流 v4.0.7 ベースの `4.0.7-Enhanced.2` です。
+現在のバージョンは上流 v4.0.7 ベースの `4.0.7-Enhanced.3` です。
 
 Free および Go アカウントでは、Codex のネイティブモデル選択画面に
 **ChatGPT Web — Luna** が追加されます。reasoning セレクターが表示されるアカウントでは、

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 This independently maintained **Enhanced** fork tracks the upstream release base and adds an
 opt-in Web-session lifecycle for long-running Codex and Claude Code work. Fork releases use the
 `<upstream>-Enhanced.<revision>` version format, beginning with `3.0.1-Enhanced.1`.
-The current version is `4.0.7-Enhanced.2`, based on upstream v4.0.7.
+The current version is `4.0.7-Enhanced.3`, based on upstream v4.0.7.
 
 Free and Go accounts get **ChatGPT Web — Luna** in Codex's native model picker. Accounts that
 expose the reasoning selector keep **Instant**, **Medium**, **High**, **Extra High**, and **Pro** as

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -24,7 +24,7 @@
 
 这是独立维护的 **Enhanced** fork：在持续跟进上游基线的同时，提供可选的长任务 Web 会话
 生命周期。Fork 版本采用 `<上游版本>-Enhanced.<修订号>`，首个版本为 `3.0.1-Enhanced.1`。
-当前版本为基于上游 v4.0.7 的 `4.0.7-Enhanced.2`。
+当前版本为基于上游 v4.0.7 的 `4.0.7-Enhanced.3`。
 
 Free 和 Go 账户会在 Codex 原生模型选择器中看到 **ChatGPT Web — Luna**。具有推理选择器的
 账户仍会按订阅权限看到 **Instant**、**Medium**、**High**、**Extra High** 和 **Pro**。

--- a/launcher/package.json
+++ b/launcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-web-gpt-launcher",
-  "version": "4.0.7-Enhanced.2",
+  "version": "4.0.7-Enhanced.3",
   "private": true,
   "description": "Desktop control center for Codex ChatGPT Web",
   "author": "miuuyy",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-chatgpt-web",
-  "version": "4.0.7-Enhanced.2",
+  "version": "4.0.7-Enhanced.3",
   "private": true,
   "description": "A focused local Responses bridge that runs Codex tasks through a user-authenticated ChatGPT web session.",
   "repository": {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2,7 +2,7 @@
 set -eu
 
 REPOSITORY="${CODEX_CHATGPT_WEB_REPOSITORY:-Evanlau1798/codex-chatgpt-web}"
-VERSION="${CODEX_CHATGPT_WEB_VERSION:-4.0.7-Enhanced.2}"
+VERSION="${CODEX_CHATGPT_WEB_VERSION:-4.0.7-Enhanced.3}"
 BIN_DIR="${CODEX_CHATGPT_WEB_BIN_DIR:-$HOME/.local/bin}"
 LIB_DIR="${CODEX_CHATGPT_WEB_LIB_DIR:-$HOME/.local/lib/codex-chatgpt-web}"
 DOC_DIR="${CODEX_CHATGPT_WEB_DOC_DIR:-$HOME/.local/share/doc/codex-chatgpt-web}"

--- a/src/adapters/chatgpt-web/browser-worker.ts
+++ b/src/adapters/chatgpt-web/browser-worker.ts
@@ -1177,6 +1177,7 @@ export class ChatGptBrowserWorker {
       ]);
       if (ready === "rate-limit") await throwIfChatGptRateLimitDialog(page);
       if (ready === "session-expired") await throwIfChatGptSessionFailureAlert(page);
+      if (ready !== "slider" && await effortSlider.isVisible().catch(() => false)) ready = "slider";
       await captureDiagnostic?.(ready === "slider" ? "effort-slider-visible" : "effort-choice-visible");
     } catch (error) {
       if (error instanceof ChatGptWebAdapterError) throw error;

--- a/src/adapters/chatgpt-web/browser-worker.ts
+++ b/src/adapters/chatgpt-web/browser-worker.ts
@@ -1177,7 +1177,14 @@ export class ChatGptBrowserWorker {
       ]);
       if (ready === "rate-limit") await throwIfChatGptRateLimitDialog(page);
       if (ready === "session-expired") await throwIfChatGptSessionFailureAlert(page);
-      if (ready !== "slider" && await effortSlider.isVisible().catch(() => false)) ready = "slider";
+      if (ready !== "slider" && (await effortSlider.count().catch(() => 0)) > 0) {
+        const attachedSliderState = parseChatGptEffortSliderState(
+          await effortSlider.getAttribute("aria-valuemin"),
+          await effortSlider.getAttribute("aria-valuemax"),
+          await effortSlider.getAttribute("aria-valuenow"),
+        );
+        if (attachedSliderState) ready = "slider";
+      }
       await captureDiagnostic?.(ready === "slider" ? "effort-slider-visible" : "effort-choice-visible");
     } catch (error) {
       if (error instanceof ChatGptWebAdapterError) throw error;

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = "4.0.7-Enhanced.2";
+export const VERSION = "4.0.7-Enhanced.3";

--- a/tests/browser-worker-effort-retry.test.ts
+++ b/tests/browser-worker-effort-retry.test.ts
@@ -91,6 +91,73 @@ async function effortMenuError(itemCount: number): Promise<ChatGptWebAdapterErro
 }
 
 describe("ChatGPT effort menu failure classification", () => {
+  test("prefers a visible effort slider over model radio rows in the same picker", async () => {
+    let sliderValue = 3;
+    const pressed: string[] = [];
+    const modelRow = {
+      waitFor: async () => {},
+      getAttribute: async () => "false",
+      press: async () => { throw new Error("model row was activated as effort"); },
+    };
+    const slider = {
+      waitFor: async () => await new Promise(resolve => setTimeout(resolve, 0)),
+      isVisible: async () => true,
+      getAttribute: async (name: string) => ({
+        "aria-valuemin": "0",
+        "aria-valuemax": "4",
+        "aria-valuenow": String(sliderValue),
+      })[name as "aria-valuemin" | "aria-valuemax" | "aria-valuenow"],
+      locator: () => ({
+        press: async (key: string) => {
+          pressed.push(key);
+          sliderValue += key === "ArrowLeft" ? -1 : 1;
+        },
+      }),
+    };
+    const effortMenu = {
+      last() { return this; },
+      isVisible: async () => true,
+      locator: () => ({ nth: () => modelRow }),
+    };
+    const effortControl = {
+      last() { return this; },
+      waitFor: async () => {},
+      getAttribute: async () => "true",
+    };
+    const hiddenDialog = {
+      filter() { return this; },
+      last() { return this; },
+      isVisible: async () => false,
+      waitFor: () => new Promise(() => {}),
+    };
+    const page = {
+      locator: (selector: string) => {
+        if (selector === CHATGPT_EFFORT_MENU_SELECTOR) return effortMenu;
+        if (selector === CHATGPT_EFFORT_SLIDER_SELECTOR) return { last: () => slider };
+        if (selector.includes('[role="alert"]') || selector.includes('[role="dialog"]')) return hiddenDialog;
+        throw new Error(`Unexpected selector: ${selector}`);
+      },
+      keyboard: { press: async () => {} },
+    };
+    const composer = { locator: () => ({ locator: () => effortControl }) };
+    const selectModelAndEffort = (ChatGptBrowserWorker.prototype as unknown as {
+      selectModelAndEffort(
+        page: unknown,
+        modelId: string,
+        reasoning: string,
+        capabilities: { localToolsEnabled: boolean; solAvailable: boolean; proAvailable: boolean },
+      ): Promise<unknown>;
+    }).selectModelAndEffort;
+
+    await expect(selectModelAndEffort.call({ activeComposer: async () => composer },
+      page, CHATGPT_WEB_MODEL_ID, "medium", {
+        localToolsEnabled: true,
+        solAvailable: true,
+        proAvailable: false,
+      })).resolves.toBeDefined();
+    expect(pressed).toEqual(["ArrowLeft", "ArrowLeft"]);
+  });
+
   test("selects an attached semantic slider even when its thumb has no visible box", async () => {
     let sliderValue = 3;
     const pressed: string[] = [];

--- a/tests/browser-worker-effort-retry.test.ts
+++ b/tests/browser-worker-effort-retry.test.ts
@@ -91,7 +91,7 @@ async function effortMenuError(itemCount: number): Promise<ChatGptWebAdapterErro
 }
 
 describe("ChatGPT effort menu failure classification", () => {
-  test("prefers a visible effort slider over model radio rows in the same picker", async () => {
+  test("prefers an attached semantic effort slider over model radio rows in the same picker", async () => {
     let sliderValue = 3;
     const pressed: string[] = [];
     const modelRow = {
@@ -101,7 +101,8 @@ describe("ChatGPT effort menu failure classification", () => {
     };
     const slider = {
       waitFor: async () => await new Promise(resolve => setTimeout(resolve, 0)),
-      isVisible: async () => true,
+      count: async () => 1,
+      isVisible: async () => false,
       getAttribute: async (name: string) => ({
         "aria-valuemin": "0",
         "aria-valuemax": "4",


### PR DESCRIPTION
## Summary
- make the redesigned combined ChatGPT model/effort picker prefer its semantic effort slider over model radio rows
- preserve attached hidden-slider support by requiring a valid ARIA range instead of visual geometry
- prepare the fork version as 4.0.7-Enhanced.3

## Regression evidence
- the RED fixture reproduced a model row winning the readiness race while the valid effort slider was attached
- the adapter previously activated that model row instead of changing Medium effort
- the focused GREEN suite now proves both combined-picker and hidden-slider behavior

## Validation
- focused effort/session suites: 13 passed
- bounded root suite: 131 files passed
- launcher suite: 278 passed, 1 platform skip
- root and launcher TypeScript checks passed
- deterministic Codex, Claude, and all lanes passed
- root and launcher audits reported no vulnerabilities
- relocatable runtime build and smoke passed
- Windows Electron 41.10.7 package and packaged-app smoke passed
- atomic source restart healthy on 4.0.7-Enhanced.3
- one low-usage Web contract smoke passed all capabilities with final browser idle

## Release
After PR and post-merge main CI pass, this change is intended for the formal v4.0.7-Enhanced.3 release.