### PR TITLE
fix: fetch upstream history in release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,8 @@ jobs:
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: 1.4.0

--- a/tests/lifecycle-profiles.test.ts
+++ b/tests/lifecycle-profiles.test.ts
@@ -79,11 +79,13 @@ test("contributor guidance defines the lifecycle profiles without untracked docs
 
 test("release builds rerun the deterministic lifecycle gate at the tag SHA", () => {
   const workflow = readFileSync(resolve(repo, ".github", "workflows", "release.yml"), "utf8");
+  const build = workflow.match(/\r?\n  build:\r?\n([\s\S]*?)\r?\n  publish:/)?.[1];
   expect(workflow).toContain("lifecycle-gate:");
   expect(workflow).toContain("bun run lifecycle:sim --lane=all");
   expect(workflow).toContain("@openai/codex@0.150.1");
   expect(workflow).toContain("@anthropic-ai/claude-code@2.1.251");
   expect(workflow).toMatch(/build:\s+needs: lifecycle-gate/);
+  expect(build).toContain("fetch-depth: 0");
 });
 
 test("latest-client canary runs both offline lanes and always reports safe status", () => {


### PR DESCRIPTION
## Summary

- fixes the failed `v4.0.8-Enhanced.1` release run by fetching full Git history in the release build matrix
- keeps the upstream obligation ledger strict instead of skipping it during tag builds
- adds a focused contract proving release verification has the ancestry it requires

## Evidence

The first tag run failed on all four platforms before packaging because `tests/upstream-audit-ledger.test.ts` could not resolve the pinned upstream range from a shallow checkout. CI verification already used `fetch-depth: 0`; this PR closes the equivalent release-workflow gap.

Focused lifecycle/release-profile and upstream-ledger tests pass locally. Local actionlint was unavailable because Go is not installed; the required CI actionlint job remains the authoritative check.
