### PR TITLE
fix: bind upstream receipt to canonical blob bytes

### DIFF
--- a/.github/upstream-audit/v4.0.8-publication.json
+++ b/.github/upstream-audit/v4.0.8-publication.json
@@ -18,7 +18,7 @@
   "ledger": {
     "path": ".github/upstream-audit/v4.0.8.json",
     "blob": "a80b3a032b0e337f9fef5ebfb987d5d4cbf6a5a1",
-    "sha256": "ae23cf797cac720be9c582af7dcd93d8e11d5818cb16fc045d015d0c49a4667b"
+    "sha256": "c904f0095bb830c0df4955f3aa273d8e09d7f4a2faf05f196bfe8fa4ceb2bb47"
   },
   "ci": {
     "upstream": {

--- a/tests/upstream-audit-ledger.test.ts
+++ b/tests/upstream-audit-ledger.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { createHash } from "node:crypto";
 import { readFileSync } from "node:fs";
 import { spawnSync } from "node:child_process";
 import { resolve } from "node:path";
@@ -24,10 +25,21 @@ type Ledger = {
   entries: LedgerEntry[];
 };
 
+type PublicationReceipt = {
+  integration: { githubMerge: string };
+  ledger: { path: string; blob: string; sha256: string };
+};
+
+const repositoryRoot = resolve(import.meta.dir, "..");
+
 const ledger = JSON.parse(readFileSync(
-  resolve(import.meta.dir, "..", ".github", "upstream-audit", "v4.0.8.json"),
+  resolve(repositoryRoot, ".github", "upstream-audit", "v4.0.8.json"),
   "utf8",
 )) as Ledger;
+const publication = JSON.parse(readFileSync(
+  resolve(repositoryRoot, ".github", "upstream-audit", "v4.0.8-publication.json"),
+  "utf8",
+)) as PublicationReceipt;
 const sha = /^[0-9a-f]{40}$/;
 
 describe("upstream v4.0.8 audit ledger", () => {
@@ -67,5 +79,20 @@ describe("upstream v4.0.8 audit ledger", () => {
       return { changeType: match[1], path: match[2] };
     });
     expect(paths).toEqual(ledger.entries.map(({ changeType, path }) => ({ changeType, path })));
+  });
+
+  test("binds the publication receipt to canonical Git blob bytes", () => {
+    const committedBlob = spawnSync("git", [
+      "rev-parse", `${publication.integration.githubMerge}:${publication.ledger.path}`,
+    ], { cwd: repositoryRoot, encoding: "utf8" });
+    expect(committedBlob.status).toBe(0);
+    expect(committedBlob.stdout.trim()).toBe(publication.ledger.blob);
+
+    const blob = spawnSync("git", ["cat-file", "blob", publication.ledger.blob], {
+      cwd: repositoryRoot,
+    });
+    expect(blob.status).toBe(0);
+    expect(createHash("sha256").update(blob.stdout).digest("hex"))
+      .toBe(publication.ledger.sha256);
   });
 });


### PR DESCRIPTION
## Summary

- replace the CRLF-derived v4.0.8 publication digest with the SHA-256 of the canonical Git blob bytes
- verify that the recorded blob is the ledger stored by the published integration merge
- hash `git cat-file blob` output directly so the contract is independent of checkout line endings

## Review finding

Addresses the P1 audit-integrity finding in PR #10: https://github.com/Evanlau1798/codex-chatgpt-web/pull/10#discussion_r3910057085

## Verification

- RED: focused audit test received `c904f009...` while the receipt recorded `ae23cf79...`
- GREEN: focused audit tests: 4 passed, 0 failed
- bounded root suite: 141 test files passed
- root TypeScript typecheck: passed
- independent targeted review: no findings
- `git diff --check`: passed

## Release impact

This corrects audit metadata and its executable verifier only. It does not change runtime, server, launcher, package version, or release artifacts, so no new Enhanced release is required.
