### PR TITLE
fix: harden ChatGPT composer restoration

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,3 +84,9 @@ HTTP or browser turn, no live session registry entry, and no active broker capab
 verification limit stops the run immediately without retry. The old full live lifecycle flow is a
 manual `deep` diagnostic profile, never a default CI or release gate. Redacted artifacts belong
 under `tmp/lifecycle-smoke/runs/` and must never be committed.
+
+Before a release-bound push, tag, or publication, run every account-bound smoke required by the
+changed scope against the exact candidate runtime. Browser UI or Web transport changes always
+require `bun run smoke:lifecycle:web`; an earlier run against another installed version is not
+release evidence. Run the request-heavy `deep` profile only when the changed lifecycle scope or a
+specific investigation requires it, and keep the no-retry rule for 429 or verification limits.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,9 +85,9 @@ verification limit stops the run immediately without retry. The old full live li
 manual `deep` diagnostic profile, never a default CI or release gate. Redacted artifacts belong
 under `tmp/lifecycle-smoke/runs/` and must never be committed.
 
-Before a release-bound push, tag, or publication, run `bun run verify:release` locally against the
-exact candidate runtime. This hard gate runs the full offline verification first, then sends one
-short account-bound Web request through `bun run smoke:lifecycle:web`; CI intentionally runs only
+Before a release-bound push, tag, or publication, run `bun run verify:release` locally. This hard
+gate runs the full offline verification, starts the freshly built candidate runtime on an isolated
+loopback port, then sends one short account-bound Web request through it. CI intentionally runs only
 `bun run verify` because hosted runners have no login state. An earlier run against another runtime
 is not release evidence. Run the request-heavy `deep` profile only when the changed lifecycle scope
 or a specific investigation requires it, and keep the no-retry rule for 429 or verification limits.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,8 +85,9 @@ verification limit stops the run immediately without retry. The old full live li
 manual `deep` diagnostic profile, never a default CI or release gate. Redacted artifacts belong
 under `tmp/lifecycle-smoke/runs/` and must never be committed.
 
-Before a release-bound push, tag, or publication, run every account-bound smoke required by the
-changed scope against the exact candidate runtime. Browser UI or Web transport changes always
-require `bun run smoke:lifecycle:web`; an earlier run against another installed version is not
-release evidence. Run the request-heavy `deep` profile only when the changed lifecycle scope or a
-specific investigation requires it, and keep the no-retry rule for 429 or verification limits.
+Before a release-bound push, tag, or publication, run `bun run verify:release` locally against the
+exact candidate runtime. This hard gate runs the full offline verification first, then sends one
+short account-bound Web request through `bun run smoke:lifecycle:web`; CI intentionally runs only
+`bun run verify` because hosted runners have no login state. An earlier run against another runtime
+is not release evidence. Run the request-heavy `deep` profile only when the changed lifecycle scope
+or a specific investigation requires it, and keep the no-retry rule for 429 or verification limits.

--- a/README.ja.md
+++ b/README.ja.md
@@ -25,7 +25,7 @@
 この独立管理の **Enhanced** fork は上流リリースを追跡し、長時間実行する Codex／Claude Code
 タスク向けの Web セッションライフサイクルを追加します。fork のバージョンは
 `<upstream>-Enhanced.<revision>` 形式で、`3.0.1-Enhanced.1` から始まりました。
-現在のバージョンは上流 v4.0.8 ベースの `4.0.8-Enhanced.1` です。
+現在のバージョンは上流 v4.0.8 ベースの `4.0.8-Enhanced.2` です。
 
 Free および Go アカウントでは、Codex のネイティブモデル選択画面に
 **ChatGPT Web — Luna** が追加されます。reasoning セレクターが表示されるアカウントでは、

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 This independently maintained **Enhanced** fork tracks the upstream release base and adds an
 opt-in Web-session lifecycle for long-running Codex and Claude Code work. Fork releases use the
 `<upstream>-Enhanced.<revision>` version format, beginning with `3.0.1-Enhanced.1`.
-The current version is `4.0.8-Enhanced.1`, based on upstream v4.0.8.
+The current version is `4.0.8-Enhanced.2`, based on upstream v4.0.8.
 
 Free and Go accounts get **ChatGPT Web — Luna** in Codex's native model picker. Accounts that
 expose the reasoning selector keep **Instant**, **Medium**, **High**, **Extra High**, and **Pro** as

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -24,7 +24,7 @@
 
 这是独立维护的 **Enhanced** fork：在持续跟进上游基线的同时，提供可选的长任务 Web 会话
 生命周期。Fork 版本采用 `<上游版本>-Enhanced.<修订号>`，首个版本为 `3.0.1-Enhanced.1`。
-当前版本为基于上游 v4.0.8 的 `4.0.8-Enhanced.1`。
+当前版本为基于上游 v4.0.8 的 `4.0.8-Enhanced.2`。
 
 Free 和 Go 账户会在 Codex 原生模型选择器中看到 **ChatGPT Web — Luna**。具有推理选择器的
 账户仍会按订阅权限看到 **Instant**、**Medium**、**High**、**Extra High** 和 **Pro**。

--- a/launcher/package.json
+++ b/launcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-web-gpt-launcher",
-  "version": "4.0.8-Enhanced.1",
+  "version": "4.0.8-Enhanced.2",
   "private": true,
   "description": "Desktop control center for Codex ChatGPT Web",
   "author": "miuuyy",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-chatgpt-web",
-  "version": "4.0.8-Enhanced.1",
+  "version": "4.0.8-Enhanced.2",
   "private": true,
   "description": "A focused local Responses bridge that runs Codex tasks through a user-authenticated ChatGPT web session.",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
     "launcher:typecheck": "bun run --cwd launcher typecheck",
     "launcher:build": "bun run --cwd launcher build",
     "launcher:test": "bun run --cwd launcher test",
-    "verify": "bun run scripts/verify.ts"
+    "verify": "bun run scripts/verify.ts",
+    "verify:release": "bun run verify && bun run smoke:lifecycle:web"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "launcher:build": "bun run --cwd launcher build",
     "launcher:test": "bun run --cwd launcher test",
     "verify": "bun run scripts/verify.ts",
-    "verify:release": "bun run verify && bun run smoke:lifecycle:web"
+    "verify:release": "bun run scripts/verify.ts --live-web"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.30.0",

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2,7 +2,7 @@
 set -eu
 
 REPOSITORY="${CODEX_CHATGPT_WEB_REPOSITORY:-Evanlau1798/codex-chatgpt-web}"
-VERSION="${CODEX_CHATGPT_WEB_VERSION:-4.0.8-Enhanced.1}"
+VERSION="${CODEX_CHATGPT_WEB_VERSION:-4.0.8-Enhanced.2}"
 BIN_DIR="${CODEX_CHATGPT_WEB_BIN_DIR:-$HOME/.local/bin}"
 LIB_DIR="${CODEX_CHATGPT_WEB_LIB_DIR:-$HOME/.local/lib/codex-chatgpt-web}"
 DOC_DIR="${CODEX_CHATGPT_WEB_DOC_DIR:-$HOME/.local/share/doc/codex-chatgpt-web}"

--- a/scripts/lifecycle-smoke/web-contract-core.ts
+++ b/scripts/lifecycle-smoke/web-contract-core.ts
@@ -1,4 +1,5 @@
 export const WEB_CONTRACT_COOLDOWN_MS = 2 * 60_000;
+export const WEB_CONTRACT_TURN_TIMEOUT_MS = 3 * 60_000;
 
 const capabilityKeys = [
   "authenticated",
@@ -59,7 +60,7 @@ export function assertWebContractCooldown(lastRunAt: number | undefined, now = D
 }
 
 export function webContractBrowserIsIdle(health: Record<string, unknown>): boolean {
-  return Number(health.active_browser_turns ?? 0) === 0;
+  return Number.isSafeInteger(health.active_browser_turns) && health.active_browser_turns === 0;
 }
 
 export function assertWebContractRuntimeVersion(

--- a/scripts/lifecycle-smoke/web-contract-core.ts
+++ b/scripts/lifecycle-smoke/web-contract-core.ts
@@ -62,6 +62,26 @@ export function webContractBrowserIsIdle(health: Record<string, unknown>): boole
   return Number(health.active_browser_turns ?? 0) === 0;
 }
 
+export function assertWebContractRuntimeVersion(
+  health: Record<string, unknown>,
+  expectedVersion: string,
+  expectedPid?: number,
+): number {
+  if (health.version !== expectedVersion) {
+    throw new Error(
+      `Web contract smoke requires the candidate version: expected=${expectedVersion} actual=${String(health.version ?? "missing")}`,
+    );
+  }
+  const pid = Number(health.pid);
+  if (!Number.isSafeInteger(pid) || pid <= 0) {
+    throw new Error("Web contract smoke requires a verified runtime process");
+  }
+  if (expectedPid !== undefined && pid !== expectedPid) {
+    throw new Error(`Web contract smoke changed process during the live turn: expectedPid=${expectedPid} actualPid=${pid}`);
+  }
+  return pid;
+}
+
 export async function requestWebContractTurn(
   fetcher: (request: Request) => Promise<Response>,
   request: Request,

--- a/scripts/lifecycle-smoke/web-contract.ts
+++ b/scripts/lifecycle-smoke/web-contract.ts
@@ -14,6 +14,7 @@ import {
   deriveWebContractCapabilities,
   requestWebContractTurn,
   responseHasFinalProjection,
+  WEB_CONTRACT_TURN_TIMEOUT_MS,
   webContractBrowserIsIdle,
 } from "./web-contract-core";
 
@@ -107,6 +108,7 @@ const metadata = {
 const request = new Request(`${baseUrl}/v1/responses`, {
   method: "POST",
   headers: { "content-type": "application/json" },
+  signal: AbortSignal.timeout(WEB_CONTRACT_TURN_TIMEOUT_MS),
   body: JSON.stringify({
     model: "chatgpt-web/high",
     stream: false,
@@ -116,7 +118,10 @@ const request = new Request(`${baseUrl}/v1/responses`, {
       thread_id: threadId,
       "x-codex-turn-metadata": JSON.stringify(metadata),
     },
-    input: [item("msg_web_contract_environment", environment), item("msg_web_contract_prompt", "Reply briefly to confirm this turn completed.")],
+    input: [
+      item("msg_web_contract_environment", environment),
+      item("msg_web_contract_prompt", "Reply briefly to confirm this turn completed.\n\nVerification: **bold**, `code`, and _emphasis_."),
+    ],
     tools: [],
   }),
 });

--- a/scripts/lifecycle-smoke/web-contract.ts
+++ b/scripts/lifecycle-smoke/web-contract.ts
@@ -2,6 +2,7 @@ import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { detectChatGptAccountCapabilities, isTemporaryChatGptUrl } from "../../src/chatgpt-session";
 import { loadConfig } from "../../src/config";
+import { VERSION } from "../../src/version";
 import {
   connectLauncherBrowserHost,
   inspectLauncherBrowserHost,
@@ -9,6 +10,7 @@ import {
 } from "../../src/launcher-browser-host";
 import {
   assertWebContractCooldown,
+  assertWebContractRuntimeVersion,
   deriveWebContractCapabilities,
   requestWebContractTurn,
   responseHasFinalProjection,
@@ -63,6 +65,7 @@ if (before.status !== "ok" || before.accepting_turns !== true
   || !webContractBrowserIsIdle(before)) {
   throw new Error("Web contract smoke requires a healthy, accepting daemon without another Web turn");
 }
+const runtimePid = assertWebContractRuntimeVersion(before, VERSION);
 const now = Date.now();
 assertWebContractCooldown(lastRunAt(), now);
 mkdirSync(artifactDir, { recursive: true });
@@ -119,20 +122,22 @@ const request = new Request(`${baseUrl}/v1/responses`, {
 });
 const result = await requestWebContractTurn(fetch, request);
 if (result.status === "account-blocked") {
-  save({ status: "account-blocked", httpStatus: 429, at: new Date(now).toISOString() });
+  save({ status: "account-blocked", runtimeVersion: VERSION, httpStatus: 429, at: new Date(now).toISOString() });
   throw new Error("WEB_CONTRACT_ACCOUNT_BLOCKED: ChatGPT returned a rate or verification limit; no retry was attempted");
 }
 if (!result.response.ok) throw new Error(`Web contract turn failed: HTTP ${result.response.status}`);
 const payload = await result.response.json();
 const finalProjection = responseHasFinalProjection(payload);
 if (!finalProjection) throw new Error("Web contract turn did not complete a final projection");
+const browserIdle = await waitForBrowserIdle(baseUrl);
+assertWebContractRuntimeVersion(await health(baseUrl), VERSION, runtimePid);
 const capture = deriveWebContractCapabilities({
   session,
   connectorVerified,
   responseAccepted: result.response.ok,
   finalProjection,
-  browserIdle: await waitForBrowserIdle(baseUrl),
+  browserIdle,
 });
 if (Object.values(capture).some(value => !value)) throw new Error("Web contract smoke did not return browser idle");
-save({ status: "passed", at: new Date(now).toISOString(), capabilities: capture });
+save({ status: "passed", runtimeVersion: VERSION, at: new Date(now).toISOString(), capabilities: capture });
 process.stdout.write(`WEB_CONTRACT_SMOKE_OK ${JSON.stringify(capture)}\n`);

--- a/scripts/smoke-candidate-web.ts
+++ b/scripts/smoke-candidate-web.ts
@@ -1,0 +1,169 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { join, resolve } from "node:path";
+import { type AppConfig, defaultBrokerEndpoint, loadConfig } from "../src/config";
+import { VERSION } from "../src/version";
+import { WEB_CONTRACT_TURN_TIMEOUT_MS, webContractBrowserIsIdle } from "./lifecycle-smoke/web-contract-core";
+
+const CONTROL_TIMEOUT_MS = 5_000;
+
+const repo = resolve(import.meta.dir, "..");
+const require = createRequire(import.meta.url);
+const { validateRuntimeBundle } = require("../launcher/electron/runtime-install.cjs") as {
+  validateRuntimeBundle(root: string, identity: { version: string; platform: string; arch: string }): string;
+};
+
+export function candidateWebConfig(
+  current: AppConfig,
+  home: string,
+  port: number,
+): AppConfig {
+  return {
+    ...current,
+    releaseVersion: VERSION,
+    host: "127.0.0.1",
+    port,
+    brokerSocketPath: defaultBrokerEndpoint(home),
+  };
+}
+
+async function waitForHealth(baseUrl: string, pid: number): Promise<void> {
+  const deadline = Date.now() + 10_000;
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(`${baseUrl}/healthz`, { signal: AbortSignal.timeout(CONTROL_TIMEOUT_MS) });
+      const health = response.ok ? await response.json() as Record<string, unknown> : undefined;
+      if (health?.version === VERSION && health.pid === pid) return;
+    } catch {}
+    await Bun.sleep(50);
+  }
+  throw new Error("Candidate runtime did not become healthy");
+}
+
+async function control(baseUrl: string, action: "drain" | "shutdown", token: string): Promise<void> {
+  const response = await fetch(`${baseUrl}/admin/${action}`, {
+    method: "POST",
+    headers: { authorization: `Bearer ${token}` },
+    signal: AbortSignal.timeout(CONTROL_TIMEOUT_MS),
+  });
+  if (!response.ok) throw new Error(`Candidate runtime refused ${action}: HTTP ${response.status}`);
+}
+
+async function waitForBrowserIdle(baseUrl: string): Promise<void> {
+  const deadline = Date.now() + 10_000;
+  while (Date.now() < deadline) {
+    const response = await fetch(`${baseUrl}/healthz`, { signal: AbortSignal.timeout(CONTROL_TIMEOUT_MS) });
+    if (response.ok && webContractBrowserIsIdle(await response.json() as Record<string, unknown>)) return;
+    await Bun.sleep(50);
+  }
+  throw new Error("Candidate runtime did not become browser-idle after drain");
+}
+
+async function waitForExit(child: Bun.Subprocess, timeoutMs: number): Promise<boolean> {
+  return await Promise.race([
+    child.exited.then(() => true),
+    Bun.sleep(timeoutMs).then(() => false),
+  ]);
+}
+
+async function terminate(child: Bun.Subprocess): Promise<void> {
+  if (await waitForExit(child, 100)) return;
+  child.kill();
+  if (await waitForExit(child, 5_000)) return;
+  child.kill(9);
+  if (!await waitForExit(child, 5_000)) throw new Error("Candidate runtime cleanup timed out");
+}
+
+async function stopCandidate(child: Bun.Subprocess, baseUrl: string, token: string): Promise<void> {
+  let gracefulError: unknown;
+  try {
+    await control(baseUrl, "drain", token);
+    await waitForBrowserIdle(baseUrl);
+    await control(baseUrl, "shutdown", token);
+    if (!await waitForExit(child, 5_000)) throw new Error("Candidate runtime did not exit after shutdown");
+    return;
+  } catch (error) {
+    gracefulError = error;
+  }
+  await terminate(child);
+  throw gracefulError;
+}
+
+async function runWebContract(env: Record<string, string | undefined>): Promise<void> {
+  const smoke = Bun.spawn([process.execPath, "run", join(repo, "scripts", "lifecycle-smoke", "web-contract.ts")], {
+    cwd: repo,
+    env,
+    stdin: "ignore",
+    stdout: "inherit",
+    stderr: "inherit",
+  });
+  const exitCode = await Promise.race([
+    smoke.exited,
+    Bun.sleep(WEB_CONTRACT_TURN_TIMEOUT_MS + 30_000).then(() => undefined),
+  ]);
+  if (exitCode === undefined) {
+    await terminate(smoke);
+    throw new Error("Candidate Web smoke timed out");
+  }
+  if (exitCode !== 0) throw new Error("Candidate runtime Web contract smoke failed");
+}
+
+async function main(): Promise<void> {
+  const runtimeRoot = resolve(process.argv[2] ?? "");
+  validateRuntimeBundle(runtimeRoot, { version: VERSION, platform: process.platform, arch: process.arch });
+  const manifest = JSON.parse(readFileSync(join(runtimeRoot, "manifest.json"), "utf8")) as {
+    entrypoint?: unknown;
+  };
+  if (typeof manifest.entrypoint !== "string") throw new Error("Candidate runtime manifest has no entrypoint");
+  const runtimeCommand = [
+    join(runtimeRoot, "runtime", process.platform === "win32" ? "bun.exe" : "bun"),
+    join(runtimeRoot, manifest.entrypoint),
+  ];
+  const current = loadConfig();
+  if (current.mode !== "full" || current.browserHost !== "launcher" || !current.browserHostDescriptorPath
+    || !current.useEnhancedWebSessionMode) {
+    throw new Error("Candidate Web smoke requires the Enhanced full-mode launcher browser host");
+  }
+
+  mkdirSync(join(repo, "tmp"), { recursive: true });
+  const root = mkdtempSync(join(repo, "tmp", "candidate-web-"));
+  let child: Bun.Subprocess | undefined;
+  let baseUrl: string | undefined;
+  let controlToken: string | undefined;
+  try {
+    const home = join(root, "home");
+    mkdirSync(home);
+    const listener = Bun.listen({ hostname: "127.0.0.1", port: 0, socket: { data() {} } });
+    const port = listener.port;
+    listener.stop();
+    const config = candidateWebConfig(current, home, port);
+    controlToken = config.controlToken;
+    writeFileSync(join(home, "config.json"), `${JSON.stringify(config, null, 2)}\n`, { mode: 0o600 });
+    const env = { ...process.env, CODEX_CHATGPT_WEB_HOME: home };
+    child = Bun.spawn([...runtimeCommand, "serve"], {
+      cwd: runtimeRoot,
+      env,
+      stdin: "ignore",
+      stdout: "inherit",
+      stderr: "inherit",
+    });
+    baseUrl = `http://127.0.0.1:${port}`;
+    await waitForHealth(baseUrl, child.pid);
+    await runWebContract(env);
+  } finally {
+    let cleanupError: unknown;
+    try {
+      if (child && baseUrl && controlToken) await stopCandidate(child, baseUrl, controlToken);
+    } catch (error) {
+      cleanupError = error;
+    }
+    try {
+      rmSync(root, { recursive: true, force: true });
+    } catch (error) {
+      cleanupError ??= error;
+    }
+    if (cleanupError) throw cleanupError;
+  }
+}
+
+if (import.meta.main) await main();

--- a/scripts/verify.ts
+++ b/scripts/verify.ts
@@ -5,6 +5,7 @@ import { join, resolve } from "node:path";
 const root = resolve(import.meta.dir, "..");
 const scratch = mkdtempSync(join(tmpdir(), "codex-chatgpt-web-verify-"));
 const runtimeBundle = join(scratch, "runtime");
+const liveWeb = process.argv.includes("--live-web");
 
 async function run(args: string[]): Promise<void> {
   const child = Bun.spawn([process.execPath, ...args], {
@@ -34,6 +35,7 @@ try {
     "--include-launcher",
   ]);
   await run(["run", "scripts/smoke-release.ts", runtimeBundle]);
+  if (liveWeb) await run(["run", "scripts/smoke-candidate-web.ts", runtimeBundle]);
 } finally {
   rmSync(scratch, { recursive: true, force: true });
 }

--- a/src/adapters/chatgpt-web/browser-worker.ts
+++ b/src/adapters/chatgpt-web/browser-worker.ts
@@ -142,6 +142,7 @@ import { setChatGptThinkMode } from "./think-mode";
 import { dismissChatGptTemporaryChatOnboarding } from "./temporary-chat-onboarding";
 import {
   chatGptPromptAttachmentMismatch,
+  clearChatGptComposerInput,
   guardChatGptPromptChunkBoundary,
   guardChatGptPromptMarkdown,
   reanchorChatGptComposerCaret,
@@ -1758,7 +1759,7 @@ export class ChatGptBrowserWorker {
     await runChatGptMutationCleanup(async signal => {
       await page.locator("body").press("Escape", { signal, timeout: 5_000 });
       const composer = await this.activeComposer(page, 5_000, signal);
-      await composer.fill("", { signal, timeout: 5_000 });
+      await clearChatGptComposerInput(composer, signal);
       await withBrowserTurnAbort(settleChatGptUi(), signal);
       const text = await composer.evaluate(
         element => element.textContent?.trim() ?? "",

--- a/src/adapters/chatgpt-web/prompt-caret.ts
+++ b/src/adapters/chatgpt-web/prompt-caret.ts
@@ -21,6 +21,25 @@ const MARKDOWN_SHORTCUT_DELIMITERS = ["`", "*", "_", "~", "=", "[", ")"] as cons
 
 type MarkdownReplacement = { marker: string; value: string; count: number };
 
+const CHATGPT_COMPOSER_SELECT_ALL_KEY = process.platform === "darwin" ? "Meta+A" : "Control+A";
+
+export async function clearChatGptComposerInput(
+  composer: Locator,
+  abortSignal?: AbortSignal,
+): Promise<void> {
+  const options = { signal: abortSignal, timeout: 5_000 };
+  await composer.fill("", options);
+  const hasText = await composer.evaluate(
+    element => (element.textContent?.trim().length ?? 0) > 0,
+    undefined,
+    options,
+  );
+  if (!hasText) return;
+  await composer.focus(options);
+  await composer.press(CHATGPT_COMPOSER_SELECT_ALL_KEY, options);
+  await composer.press("Backspace", options);
+}
+
 export function guardChatGptPromptChunkBoundary(
   text: string,
   chunk: string,
@@ -135,6 +154,29 @@ export async function restoreChatGptPromptMarkdown(
       for (let node = walker.nextNode(); node; node = walker.nextNode()) {
         const parent = (node as Text).parentElement;
         if (!parent?.closest(ignoredSelector)) textNodes.push(node as Text);
+      }
+      const clone = element.cloneNode(true) as HTMLElement;
+      clone.querySelectorAll(ignoredSelector).forEach(part => part.remove());
+      const guardedText = Array.from(clone.childNodes, child => child.textContent ?? "").join("\n");
+      if (guardedText.length <= input.maxChars) {
+        let markerCount = 0;
+        const restoredText = Array.from(guardedText, value => {
+          const replacement = replacementsByMarker.get(value);
+          if (replacement === undefined) return value;
+          markerCount += 1;
+          return replacement;
+        }).join("");
+        const firstText = textNodes[0];
+        const lastText = textNodes.at(-1);
+        if (markerCount === 0 || !firstText || !lastText) return 0;
+        const range = document.createRange();
+        range.setStart(firstText, 0);
+        range.setEnd(lastText, lastText.data.length);
+        selection.removeAllRanges();
+        selection.addRange(range);
+        if (!document.execCommand("insertText", false, restoredText)) return 0;
+        await Promise.resolve();
+        return markerCount;
       }
       for (let nodeIndex = textNodes.length - 1; nodeIndex >= 0; nodeIndex -= 1) {
         const node = textNodes[nodeIndex]!;

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = "4.0.8-Enhanced.1";
+export const VERSION = "4.0.8-Enhanced.2";

--- a/tests/candidate-web-smoke.test.ts
+++ b/tests/candidate-web-smoke.test.ts
@@ -1,0 +1,43 @@
+import { expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { candidateWebConfig } from "../scripts/smoke-candidate-web";
+import { defaultConfig } from "../src/config";
+import { VERSION } from "../src/version";
+
+test("candidate Web smoke isolates the built daemon while preserving the launcher browser host", () => {
+  const current = Object.assign(defaultConfig("full"), {
+    releaseVersion: "old",
+    port: 17841,
+    browserHost: "launcher" as const,
+    browserHostDescriptorPath: "C:\\runtime\\launcher-browser.json",
+    useEnhancedWebSessionMode: true,
+    brokerSocketPath: "old-broker",
+    runtimeCommand: ["old-runtime"],
+  });
+  const config = candidateWebConfig(
+    current,
+    "C:\\candidate-home",
+    24567,
+  );
+
+  expect(config).toMatchObject({
+    releaseVersion: VERSION,
+    host: "127.0.0.1",
+    port: 24567,
+    browserHost: "launcher",
+    browserHostDescriptorPath: "C:\\runtime\\launcher-browser.json",
+    useEnhancedWebSessionMode: true,
+    runtimeCommand: ["old-runtime"],
+  });
+  expect(config.brokerSocketPath).not.toBe("old-broker");
+});
+
+test("candidate Web smoke drains before shutdown and bounds the live subprocess", () => {
+  const script = readFileSync(new URL("../scripts/smoke-candidate-web.ts", import.meta.url), "utf8");
+  const drainAt = script.indexOf('control(baseUrl, "drain"');
+  const shutdownAt = script.indexOf('control(baseUrl, "shutdown"');
+  expect(drainAt).toBeGreaterThan(-1);
+  expect(shutdownAt).toBeGreaterThan(drainAt);
+  expect(script).toContain("WEB_CONTRACT_TURN_TIMEOUT_MS + 30_000");
+  expect(script).toContain("Candidate Web smoke timed out");
+});

--- a/tests/lifecycle-profiles.test.ts
+++ b/tests/lifecycle-profiles.test.ts
@@ -19,6 +19,19 @@ test("default lifecycle commands stay offline and deep live smoke remains explic
   expect(pkg.scripts["smoke:lifecycle"]).toBe("bun run lifecycle:sim --lane=all");
 });
 
+test("the local release gate runs verification before the account-bound Web smoke", () => {
+  const pkg = JSON.parse(readFileSync(resolve(repo, "package.json"), "utf8")) as {
+    scripts: Record<string, string>;
+  };
+  expect(pkg.scripts["verify:release"]).toBe("bun run verify && bun run smoke:lifecycle:web");
+
+  for (const workflowName of ["ci.yml", "release.yml"]) {
+    const workflow = readFileSync(resolve(repo, ".github", "workflows", workflowName), "utf8");
+    expect(workflow).not.toContain("verify:release");
+    expect(workflow).not.toContain("smoke:lifecycle:web");
+  }
+});
+
 test("CI runs deterministic lifecycle simulation and never calls a live profile", () => {
   const workflow = readFileSync(resolve(repo, ".github", "workflows", "ci.yml"), "utf8");
   expect(workflow).toContain("bun run lifecycle:sim --lane=all");

--- a/tests/lifecycle-profiles.test.ts
+++ b/tests/lifecycle-profiles.test.ts
@@ -23,7 +23,11 @@ test("the local release gate runs verification before the account-bound Web smok
   const pkg = JSON.parse(readFileSync(resolve(repo, "package.json"), "utf8")) as {
     scripts: Record<string, string>;
   };
-  expect(pkg.scripts["verify:release"]).toBe("bun run verify && bun run smoke:lifecycle:web");
+  expect(pkg.scripts["verify:release"]).toBe("bun run scripts/verify.ts --live-web");
+
+  const verify = readFileSync(resolve(repo, "scripts", "verify.ts"), "utf8");
+  expect(verify).toContain('process.argv.includes("--live-web")');
+  expect(verify).toContain('"scripts/smoke-candidate-web.ts", runtimeBundle');
 
   for (const workflowName of ["ci.yml", "release.yml"]) {
     const workflow = readFileSync(resolve(repo, ".github", "workflows", workflowName), "utf8");

--- a/tests/prompt-caret.test.ts
+++ b/tests/prompt-caret.test.ts
@@ -2,6 +2,7 @@ import { expect, test } from "bun:test";
 import {
   chatGptCaretAtLogicalEnd,
   chatGptPromptAttachmentMismatch,
+  clearChatGptComposerInput,
   previousChatGptPromptMarkdownMarker,
 } from "../src/adapters/chatgpt-web/prompt-caret";
 
@@ -89,4 +90,43 @@ test("finds Markdown restoration markers strictly right-to-left", () => {
     value: "`",
   });
   expect(previousChatGptPromptMarkdownMarker(text, 1, replacements)).toBeUndefined();
+});
+
+test("falls back to native selection when Lexical leaves the mention probe after fill", async () => {
+  const calls: string[] = [];
+  let text = "@codex";
+  const composer = {
+    fill: async () => { calls.push("fill"); },
+    evaluate: async (reader: (element: { textContent: string }) => unknown) => reader({ textContent: text }),
+    focus: async () => { calls.push("focus"); },
+    press: async (key: string) => {
+      calls.push(key);
+      if (key === "Backspace") text = "";
+    },
+  };
+
+  await clearChatGptComposerInput(composer as never);
+
+  expect(text).toBe("");
+  expect(calls).toEqual([
+    "fill",
+    "focus",
+    process.platform === "darwin" ? "Meta+A" : "Control+A",
+    "Backspace",
+  ]);
+});
+
+test("does not issue native clearing keys when fill empties the composer", async () => {
+  const calls: string[] = [];
+  let text = "@codex";
+  const composer = {
+    fill: async () => { text = ""; calls.push("fill"); },
+    evaluate: async (reader: (element: { textContent: string }) => unknown) => reader({ textContent: text }),
+    focus: async () => { calls.push("focus"); },
+    press: async (key: string) => { calls.push(key); },
+  };
+
+  await clearChatGptComposerInput(composer as never);
+
+  expect(calls).toEqual(["fill"]);
 });

--- a/tests/prompt-markdown-restoration.test.ts
+++ b/tests/prompt-markdown-restoration.test.ts
@@ -2,6 +2,7 @@ import { expect, test } from "bun:test";
 import {
   guardChatGptPromptMarkdown,
   planChatGptPromptMarkdownRestoration,
+  restoreChatGptPromptMarkdown,
 } from "../src/adapters/chatgpt-web/prompt-caret";
 
 test("plans incident-sized Markdown restoration in bounded text ranges", () => {
@@ -36,4 +37,76 @@ test("restoration ranges carry trailing whitespace with one following code unit"
     [{ marker: "\uE000", value: "*", count: 1 }],
     8,
   )).toEqual([{ start: 1, end: 4, count: 1 }]);
+});
+
+test("restores a short multi-block prompt in one editor mutation", async () => {
+  const { createDocument } = require("@mixmark-io/domino") as {
+    createDocument: (html: string) => Document;
+  };
+  const document = createDocument(
+    '<div id="composer"><span data-id="plugin:test" data-keyword="Codex Native2">Codex Native2</span>'
+      + '<p>A\u2060one\u2060</p><p>B\uE000two\uE000</p><p>C\uE001three\uE001</p></div>',
+  ) as Document & {
+    createRange: () => Range;
+    execCommand: (command: string, showUi: boolean, value: string) => boolean;
+  };
+  const composerElement = document.getElementById("composer")!;
+  let selected: { startNode?: Node; start?: number; endNode?: Node; end?: number } = {};
+  document.createRange = () => ({
+    setStart: (node: Node, offset: number) => { selected = { startNode: node, start: offset }; },
+    setEnd: (node: Node, offset: number) => { selected.endNode = node; selected.end = offset; },
+  } as unknown as Range);
+  document.execCommand = (_command, _showUi, value) => {
+    if (selected.startNode && selected.startNode !== selected.endNode) {
+      Array.from(composerElement.children)
+        .filter(child => !child.matches('[data-id^="plugin:"][data-keyword]'))
+        .forEach(child => child.remove());
+      composerElement.appendChild(document.createTextNode(value ?? ""));
+    } else if (selected.startNode?.nodeType === 3) {
+      const node = selected.startNode as Text;
+      node.data = `${node.data.slice(0, selected.start ?? 0)}${value}${node.data.slice(selected.end ?? 0)}`;
+    }
+    return true;
+  };
+  const previousWindow = globalThis.window;
+  const previousDocument = globalThis.document;
+  const previousNodeFilter = globalThis.NodeFilter;
+  Object.assign(globalThis, {
+    document,
+    NodeFilter: { SHOW_TEXT: 4 },
+    window: {
+      getSelection: () => ({
+        removeAllRanges: () => {},
+        addRange: () => {},
+      }),
+    },
+  });
+  let evaluateCalls = 0;
+  const composer = {
+    focus: async () => {},
+    evaluate: async (callback: (element: HTMLElement, input: unknown) => unknown, input: unknown) => {
+      evaluateCalls += 1;
+      return await callback(composerElement, input);
+    },
+  };
+
+  try {
+    await expect(restoreChatGptPromptMarkdown(composer as never, [
+      { marker: "\u2060", value: "`", count: 2 },
+      { marker: "\uE000", value: "*", count: 2 },
+      { marker: "\uE001", value: "_", count: 2 },
+    ], 6)).resolves.toBeTrue();
+    expect(evaluateCalls).toBe(2);
+    const connector = composerElement.querySelector('[data-keyword="Codex Native2"]')!;
+    expect(connector).not.toBeNull();
+    expect(connector.contains(selected.startNode ?? null)).toBeFalse();
+    expect(connector.contains(selected.endNode ?? null)).toBeFalse();
+    expect(composerElement.lastChild?.textContent).toBe("A`one`\nB*two*\nC_three_");
+  } finally {
+    Object.assign(globalThis, {
+      window: previousWindow,
+      document: previousDocument,
+      NodeFilter: previousNodeFilter,
+    });
+  }
 });

--- a/tests/web-contract-smoke.test.ts
+++ b/tests/web-contract-smoke.test.ts
@@ -8,6 +8,7 @@ import {
   requestWebContractTurn,
   responseHasFinalProjection,
   WEB_CONTRACT_COOLDOWN_MS,
+  WEB_CONTRACT_TURN_TIMEOUT_MS,
   webContractBrowserIsIdle,
 } from "../scripts/lifecycle-smoke/web-contract-core";
 
@@ -76,6 +77,9 @@ describe("lightweight Web contract smoke", () => {
   test("allows unrelated HTTP turns but rejects a parallel Web turn", () => {
     expect(webContractBrowserIsIdle({ active_http_turns: 4, active_browser_turns: 0 })).toBeTrue();
     expect(webContractBrowserIsIdle({ active_http_turns: 0, active_browser_turns: 1 })).toBeFalse();
+    for (const invalid of [undefined, null, "", "0", -1, 0.5]) {
+      expect(webContractBrowserIsIdle({ active_browser_turns: invalid })).toBeFalse();
+    }
   });
 
   test("accepts any non-empty final projection without depending on model wording", () => {
@@ -133,5 +137,8 @@ describe("lightweight Web contract smoke", () => {
     const script = readFileSync(new URL("../scripts/lifecycle-smoke/web-contract.ts", import.meta.url), "utf8");
     expect(script.match(/assertWebContractRuntimeVersion\(/g)).toHaveLength(2);
     expect(script).toContain("runtimePid");
+    expect(WEB_CONTRACT_TURN_TIMEOUT_MS).toBe(180_000);
+    expect(script).toContain("AbortSignal.timeout(WEB_CONTRACT_TURN_TIMEOUT_MS)");
+    expect(script).toContain("**bold**, `code`, and _emphasis_");
   });
 });

--- a/tests/web-contract-smoke.test.ts
+++ b/tests/web-contract-smoke.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import {
   assertWebContractCooldown,
+  assertWebContractRuntimeVersion,
   captureWebContract,
   deriveWebContractCapabilities,
   requestWebContractTurn,
@@ -108,5 +109,29 @@ describe("lightweight Web contract smoke", () => {
     expect(WEB_CONTRACT_COOLDOWN_MS).toBe(120_000);
     expect(() => assertWebContractCooldown(1_000, 120_999)).toThrow("two-minute cooldown");
     expect(() => assertWebContractCooldown(1_000, 121_000)).not.toThrow();
+  });
+
+  test("requires the live daemon to match the exact release candidate version", () => {
+    expect(assertWebContractRuntimeVersion(
+      { version: "4.0.8-Enhanced.1", pid: 1234 },
+      "4.0.8-Enhanced.1",
+    )).toBe(1234);
+    expect(() => assertWebContractRuntimeVersion({ version: "4.0.7-Enhanced.3" }, "4.0.8-Enhanced.1"))
+      .toThrow("candidate version");
+    expect(() => assertWebContractRuntimeVersion({}, "4.0.8-Enhanced.1"))
+      .toThrow("candidate version");
+    expect(() => assertWebContractRuntimeVersion({ version: "4.0.8-Enhanced.1" }, "4.0.8-Enhanced.1"))
+      .toThrow("runtime process");
+    expect(() => assertWebContractRuntimeVersion(
+      { version: "4.0.8-Enhanced.1", pid: 5678 },
+      "4.0.8-Enhanced.1",
+      1234,
+    )).toThrow("changed process");
+  });
+
+  test("checks the same live runtime process before and after the account-bound turn", () => {
+    const script = readFileSync(new URL("../scripts/lifecycle-smoke/web-contract.ts", import.meta.url), "utf8");
+    expect(script.match(/assertWebContractRuntimeVersion\(/g)).toHaveLength(2);
+    expect(script).toContain("runtimePid");
   });
 });


### PR DESCRIPTION
## Summary
- harden ChatGPT composer clearing and restore short guarded Markdown prompts in one editor mutation
- bind the mandatory local live Web gate to the exact validated release-candidate runtime
- bound the account-backed turn and subprocess, drain before shutdown, and remove isolated control state on every path
- prepare version 4.0.8-Enhanced.2

## Local verification
- `bun run verify:release` (includes bounded root/launcher suites, typechecks, runtime build/smoke, and one authenticated exact-candidate Web contract turn)
- deterministic lifecycle `--lane=all`
- Windows `package:win`
- Windows `smoke:package`: `PACKAGED_LAUNCHER_SMOKE_OK win32/x64`

The live Web gate is intentionally local-only because GitHub runners do not have authenticated browser state.