### PR TITLE
fix: avoid proxy discovery in Windows Interrupt hooks

### DIFF
--- a/src/codex-interrupt-hook-windows.js
+++ b/src/codex-interrupt-hook-windows.js
@@ -129,14 +129,14 @@
       throw new Error("invalid endpoint");
     }
 
-    var request = new ActiveXObject("WinHttp.WinHttpRequest.5.1");
-    request.SetTimeouts(2000, 2000, 2000, 2000);
-    request.Open("POST", "http://127.0.0.1:" + port + "/admin/interrupt-turn", false);
-    request.SetRequestHeader("authorization", "Bearer " + token);
-    request.SetRequestHeader("content-type", "application/json");
-    request.Send('{"threadId":"' + threadId + '","turnId":"' + turnId + '"}');
-    if (request.Status < 200 || request.Status >= 300) throw new Error("request failed");
-    var result = parseJson(request.ResponseText);
+    var request = new ActiveXObject("MSXML2.ServerXMLHTTP.6.0");
+    request.setTimeouts(2000, 2000, 2000, 2000);
+    request.open("POST", "http://127.0.0.1:" + port + "/admin/interrupt-turn", false);
+    request.setRequestHeader("authorization", "Bearer " + token);
+    request.setRequestHeader("content-type", "application/json");
+    request.send('{"threadId":"' + threadId + '","turnId":"' + turnId + '"}');
+    if (request.status < 200 || request.status >= 300) throw new Error("request failed");
+    var result = parseJson(request.responseText);
     if (result.status !== "ok"
         || !nonnegativeInteger(result.cancelled_http_turns)
         || !nonnegativeInteger(result.cancelled_browser_turns)) {

--- a/tests/lifecycle-smoke-paths.test.ts
+++ b/tests/lifecycle-smoke-paths.test.ts
@@ -36,10 +36,13 @@ test("Codex process probes use Bun's native spawn path consistently", () => {
 
 test("the interrupt probe exercises the production-shaped bundled CLI hook", () => {
   const source = readFileSync(join(import.meta.dir, "..", "scripts", "smoke-codex-interrupt.ts"), "utf8");
+  const windowsHook = readFileSync(join(import.meta.dir, "..", "src", "codex-interrupt-hook-windows.js"), "utf8");
   expect(source).toContain("await Bun.build");
   expect(source).toContain('resolve(import.meta.dir, "../src/codex-interrupt-cli.ts")');
   expect(source).toContain('copyFileSync(resolve(import.meta.dir, "../src/codex-interrupt-hook-windows.js")');
   expect(source).toContain("config.runtimeCommand = [resolve(process.execPath), cliBundle]");
+  expect(windowsHook).toContain('new ActiveXObject("MSXML2.ServerXMLHTTP.6.0")');
+  expect(windowsHook).not.toContain("WinHttp.WinHttpRequest");
 });
 
 test("the POSIX runtime wrapper preserves its resolved bundle path for hook setup", () => {


### PR DESCRIPTION
## Summary

- replaces WinHTTP client proxy discovery with native ServerXMLHTTP for the loopback Interrupt hook
- preserves the exact owner, authentication, two-second request bounds, and privacy-safe failure semantics
- adds a source contract against reintroducing WinHttpRequest

## Evidence

- receipt PR #20 reproduced a 3008 ms Windows hook timeout
- current Codex Interrupt smoke passed five consecutive local runs after the change
- focused Windows shell tests and full local verify:release, including Automatic Medium live Web smoke, passed