### PR TITLE
chore: record final v5.0.1 publication evidence

### DIFF
--- a/.github/upstream-audit/v5.0.1-publication.json
+++ b/.github/upstream-audit/v5.0.1-publication.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "release": "v5.0.1",
   "targetVersion": "5.0.1-Enhanced.1",
-  "recordedAt": "2026-09-04T22:21:14.2835202Z",
+  "recordedAt": "2026-09-05T02:01:26.0562065Z",
   "repository": "https://github.com/Evanlau1798/codex-chatgpt-web",
   "tagIdentity": {
     "ref": "refs/tags/v5.0.1",
@@ -34,12 +34,32 @@
       "url": "https://github.com/Evanlau1798/codex-chatgpt-web/pull/17"
     }
   },
+  "releaseCandidateFix": {
+    "reason": "Accepted MCP calls now retain owner-scoped execution through admission expiry, and the Windows Interrupt hook uses a trusted static JScript entry with strict string identity validation so current Codex clients can complete within their fixed deadline.",
+    "candidate": "ba5331b2a6aeb34120ab5cd607f1cb19b432f2d2",
+    "githubMerge": "3c4b86709caeef78fceebe15678b601b3d250553",
+    "tree": "1039e6756af43e07f34879bde2f77ed83143883d",
+    "pullRequest": {
+      "number": 19,
+      "url": "https://github.com/Evanlau1798/codex-chatgpt-web/pull/19"
+    }
+  },
+  "proxyDiscoveryFix": {
+    "reason": "The Windows Interrupt hook now uses ServerXMLHTTP instead of WinHTTP, avoiding cold proxy discovery that could consume the current Codex client's fixed three-second hook deadline while preserving exact-turn authentication and fail-closed response validation.",
+    "candidate": "b33421d09d874bb80abcd2ed594716e3c25ba57c",
+    "githubMerge": "a6508bb2c8c15062ddb44cdecaa86016f5daa75f",
+    "tree": "36b3eef7209e2ce9d0961f1be243132be95635a0",
+    "pullRequest": {
+      "number": 21,
+      "url": "https://github.com/Evanlau1798/codex-chatgpt-web/pull/21"
+    }
+  },
   "ledger": {
     "path": ".github/upstream-audit/v5.0.1.json",
-    "commit": "5ba3ba578e0cc4f1a971ecf3a543e64044052556",
-    "blob": "b70c0e41a34eba1062f0d06f1583ac9313f33ffa",
-    "bytes": 53400,
-    "sha256": "2a0d5932e915b5b3040448cd5229854e5ca014b52737bb3993c83e2a54421545"
+    "commit": "a6508bb2c8c15062ddb44cdecaa86016f5daa75f",
+    "blob": "c7ae7f89f51fce2f28d82ae539380b434c79b200",
+    "bytes": 54340,
+    "sha256": "08a10c04237ef386b6e3b73159c6e357e5d304ace512090b3308737dbcece7c8"
   },
   "archive": {
     "path": ".github/upstream-audit/v5.0.1-evidence.tar.gz",
@@ -74,16 +94,46 @@
         "head": "d0ff5772d867fd67341b164de33cee2bba0b4da3",
         "conclusion": "success"
       },
-      "main": {
+      "postIntegrationFixMain": {
         "id": 33924156254,
         "url": "https://github.com/Evanlau1798/codex-chatgpt-web/actions/runs/33924156254",
         "head": "5ba3ba578e0cc4f1a971ecf3a543e64044052556",
         "conclusion": "success"
       },
+      "releaseCandidateFixPullRequest": {
+        "id": 33934742111,
+        "url": "https://github.com/Evanlau1798/codex-chatgpt-web/actions/runs/33934742111",
+        "head": "ba5331b2a6aeb34120ab5cd607f1cb19b432f2d2",
+        "conclusion": "success"
+      },
+      "releaseCandidateFixMain": {
+        "id": 33935296210,
+        "url": "https://github.com/Evanlau1798/codex-chatgpt-web/actions/runs/33935296210",
+        "head": "3c4b86709caeef78fceebe15678b601b3d250553",
+        "conclusion": "success"
+      },
+      "abandonedReceiptPullRequest": {
+        "id": 33935892330,
+        "url": "https://github.com/Evanlau1798/codex-chatgpt-web/actions/runs/33935892330",
+        "conclusion": "failure",
+        "disposition": "Closed without merge after its Windows latest-client probe exposed cold WinHTTP proxy discovery; the production fix was isolated in pull request 21 before rebuilding this receipt."
+      },
+      "proxyDiscoveryFixPullRequest": {
+        "id": 33936841921,
+        "url": "https://github.com/Evanlau1798/codex-chatgpt-web/actions/runs/33936841921",
+        "head": "b33421d09d874bb80abcd2ed594716e3c25ba57c",
+        "conclusion": "success"
+      },
+      "main": {
+        "id": 33937311529,
+        "url": "https://github.com/Evanlau1798/codex-chatgpt-web/actions/runs/33937311529",
+        "head": "a6508bb2c8c15062ddb44cdecaa86016f5daa75f",
+        "conclusion": "success"
+      },
       "latestClientCanary": {
-        "id": 33924953324,
-        "url": "https://github.com/Evanlau1798/codex-chatgpt-web/actions/runs/33924953324",
-        "head": "5ba3ba578e0cc4f1a971ecf3a543e64044052556",
+        "id": 33937771694,
+        "url": "https://github.com/Evanlau1798/codex-chatgpt-web/actions/runs/33937771694",
+        "head": "a6508bb2c8c15062ddb44cdecaa86016f5daa75f",
         "conclusion": "success"
       }
     }
@@ -119,10 +169,14 @@
   "validation": {
     "integrationMergeTreeMatchesCandidate": true,
     "fixMergeTreeMatchesCandidate": true,
+    "releaseCandidateFixMergeTreeMatchesCandidate": true,
+    "proxyDiscoveryFixMergeTreeMatchesCandidate": true,
     "upstreamIsMainAncestor": true,
     "auditArchiveHashesVerified": true,
     "integrationPullRequestCiPassed": true,
     "fixPullRequestCiPassed": true,
+    "releaseCandidateFixPullRequestCiPassed": true,
+    "proxyDiscoveryFixPullRequestCiPassed": true,
     "replacementMainCiPassed": true,
     "latestClientCanaryPassed": true,
     "localAutomaticAndUserOperatedZeroRiskPassed": true


### PR DESCRIPTION
## Summary
- record the final v5.0.1 release-candidate and Windows proxy-discovery remediation merges
- preserve the failed receipt run as RED evidence and retain the inherited v5.0.0 limitation
- bind the receipt to successful PR/main CI, latest-client canary, local Automatic smoke, and user-operated Zero Risk validation

## Validation
- pinned Bun 1.4.0: tests/upstream-audit-v501-ledger.test.ts (4 passed)
- publication JSON parsed successfully
- PR #19 and PR #21 candidate/merge trees match
- upstream v5.0.1 remains an ancestor

This PR changes only .github/upstream-audit/v5.0.1-publication.json.