### PR TITLE
fix: restore large Markdown prompts safely

### DIFF
--- a/scripts/lifecycle-smoke/markdown-restoration-probe.ts
+++ b/scripts/lifecycle-smoke/markdown-restoration-probe.ts
@@ -1,0 +1,193 @@
+import type { Locator, Page } from "playwright-core";
+import {
+  CHATGPT_COMPOSER_SELECTOR,
+  CHATGPT_STOP_BUTTON_SELECTOR,
+  CHATGPT_USER_TURN_SELECTOR,
+} from "../../src/chatgpt-session";
+import {
+  clearChatGptComposerInput,
+  guardChatGptPromptChunkBoundary,
+  guardChatGptPromptMarkdown,
+  reanchorChatGptComposerCaret,
+  restoreChatGptPromptMarkdown,
+} from "../../src/adapters/chatgpt-web/prompt-caret";
+import {
+  CHATGPT_PROMPT_INSERT_CHUNK_CHARS,
+  CHATGPT_UI_SETTLE_MS,
+  MAX_CHATGPT_CONNECTOR_TRIGGER_ATTEMPTS,
+} from "../../src/adapters/chatgpt-web/browser-worker";
+import { openChatGptConnectorPlusMenu } from "../../src/adapters/chatgpt-web/connector-plus-menu";
+
+export const MARKDOWN_RESTORATION_PROBE_CHARS = 17_587;
+const CONNECTOR_SELECTOR = '[data-id^="plugin:"][data-keyword]';
+
+export function markdownRestorationProbeText(): string {
+  const pattern = "field_name=value) [literal](target) `code` *bold* ~=~ payload ";
+  const text = pattern.repeat(Math.ceil(MARKDOWN_RESTORATION_PROBE_CHARS / pattern.length))
+    .slice(0, MARKDOWN_RESTORATION_PROBE_CHARS);
+  return `${text.slice(0, CHATGPT_PROMPT_INSERT_CHUNK_CHARS)} ${text.slice(CHATGPT_PROMPT_INSERT_CHUNK_CHARS + 1)}`;
+}
+
+async function activeComposer(page: Page): Promise<Locator> {
+  const composer = page.locator(CHATGPT_COMPOSER_SELECTOR).filter({ visible: true });
+  await composer.first().waitFor({ state: "visible", timeout: 20_000 });
+  if (await composer.count() !== 1) throw new Error("Markdown restoration probe requires one visible composer");
+  return composer.first();
+}
+
+async function editableText(composer: Locator): Promise<string> {
+  return composer.evaluate((element, ignoredSelector) => {
+    const clone = element.cloneNode(true) as HTMLElement;
+    clone.querySelectorAll(`${ignoredSelector}, [data-inline-selection-pill-cursor-target]`)
+      .forEach(part => part.remove());
+    return Array.from(clone.childNodes, child => child.textContent ?? "").join("\n").trimStart();
+  }, CONNECTOR_SELECTOR, { timeout: 20_000 });
+}
+
+async function connectorState(composer: Locator): Promise<string[]> {
+  return composer.evaluate((element, selector) => Array.from(
+    (element.closest("form") ?? element).querySelectorAll(selector),
+    node => node.getAttribute("data-keyword") ?? "",
+  ), CONNECTOR_SELECTOR, { timeout: 20_000 });
+}
+
+async function waitForText(composer: Locator, expected: string, abortSignal?: AbortSignal): Promise<void> {
+  const deadline = Date.now() + 20_000;
+  do {
+    if (abortSignal?.aborted) throw abortSignal.reason;
+    if (await editableText(composer) === expected) return;
+    await Bun.sleep(50);
+  } while (Date.now() < deadline);
+  throw new Error(`Markdown restoration probe text mismatch (expectedChars=${expected.length})`);
+}
+
+async function selectConnector(page: Page, appName: string): Promise<Locator> {
+  let composer = await activeComposer(page);
+  const selected = () => composer.locator("xpath=ancestor::form[1]")
+    .locator(CONNECTOR_SELECTOR)
+    .filter({ hasText: appName, visible: true });
+  const verifySelected = async (): Promise<Locator> => {
+    composer = await activeComposer(page);
+    const control = selected();
+    await control.waitFor({ state: "visible", timeout: 10_000 });
+    if (await control.count() !== 1 || await control.getAttribute("data-keyword") !== appName) {
+      throw new Error("Markdown restoration probe did not select the expected connector");
+    }
+    return composer;
+  };
+  if (await selected().count() === 1) return composer;
+
+  const plusRow = await openChatGptConnectorPlusMenu(page, appName);
+  if (plusRow) {
+    await plusRow.press("Enter", { timeout: 10_000 });
+    return await verifySelected();
+  }
+
+  const menuRows = page.locator('.__menu-item[tabindex="0"]');
+  const exactRow = menuRows.filter({ has: page.getByText(appName, { exact: true }) });
+  let attempt = 0;
+  while (attempt < MAX_CHATGPT_CONNECTOR_TRIGGER_ATTEMPTS) {
+    attempt += 1;
+    composer = await activeComposer(page);
+    await composer.fill("");
+    await composer.focus();
+    await Bun.sleep(CHATGPT_UI_SETTLE_MS);
+    await composer.pressSequentially("@codex", { delay: 25, timeout: 10_000 });
+    try {
+      await exactRow.waitFor({ state: "visible", timeout: 2_500 });
+      break;
+    } catch (error) {
+      if (!(error instanceof Error) || error.name !== "TimeoutError") throw error;
+      if (attempt === MAX_CHATGPT_CONNECTOR_TRIGGER_ATTEMPTS) {
+        throw new Error(`Markdown restoration probe could not find connector after ${attempt} attempts`);
+      }
+    }
+  }
+  if (await exactRow.count() !== 1) {
+    throw new Error("Markdown restoration probe did not find one exact connector row");
+  }
+  const rowHighlighted = async () => await exactRow.getAttribute("data-highlighted") !== null;
+  if (!await rowHighlighted()) {
+    const visibleRows = await menuRows.filter({ visible: true }).count();
+    for (let index = 0; index < visibleRows && !await rowHighlighted(); index += 1) {
+      await composer.press("ArrowDown", { timeout: 10_000 });
+    }
+  }
+  if (!await rowHighlighted()) {
+    throw new Error("Markdown restoration probe could not highlight the expected connector");
+  }
+  await composer.press("Enter", { timeout: 10_000 });
+  if (await selected().count() > 1) {
+    throw new Error("Markdown restoration probe did not select the expected connector");
+  }
+  return await verifySelected();
+}
+
+export async function runMarkdownRestorationProbe(
+  page: Page,
+  appName: string,
+  abortSignal?: AbortSignal,
+): Promise<true> {
+  const prompt = markdownRestorationProbeText();
+  const guarded = guardChatGptPromptMarkdown(prompt);
+  if (!guarded) throw new Error("Markdown restoration probe did not produce guard markers");
+  const initialUserTurns = await page.locator(CHATGPT_USER_TURN_SELECTOR).count();
+  let composer = await activeComposer(page);
+  await clearChatGptComposerInput(composer);
+  composer = await selectConnector(page, appName);
+  const connectors = await connectorState(composer);
+  if (connectors.length !== 1 || connectors[0] !== appName) {
+    throw new Error("Markdown restoration probe requires one selected connector");
+  }
+  try {
+    await composer.focus();
+    for (let offset = 0; offset < guarded.text.length; offset += CHATGPT_PROMPT_INSERT_CHUNK_CHARS) {
+      if (abortSignal?.aborted) throw abortSignal.reason;
+      const original = guarded.text.slice(offset, offset + CHATGPT_PROMPT_INSERT_CHUNK_CHARS);
+      const boundary = guardChatGptPromptChunkBoundary(guarded.text, original, offset);
+      const chunk = boundary?.text ?? original;
+      await page.keyboard.insertText(chunk);
+      composer = await activeComposer(page);
+      await waitForText(composer, `${guarded.text.slice(0, offset)}${chunk}`, abortSignal);
+      if (boundary && !await restoreChatGptPromptMarkdown(
+        composer,
+        [boundary.replacement],
+        1,
+        CHATGPT_PROMPT_INSERT_CHUNK_CHARS,
+        abortSignal,
+      )) throw new Error("Markdown restoration probe could not restore a chunk boundary");
+      if (!await reanchorChatGptComposerCaret(composer)) {
+        throw new Error("Markdown restoration probe could not re-anchor the composer");
+      }
+    }
+    composer = await activeComposer(page);
+    if (!await restoreChatGptPromptMarkdown(
+      composer,
+      guarded.replacements,
+      guarded.count,
+      CHATGPT_PROMPT_INSERT_CHUNK_CHARS,
+      abortSignal,
+    )) throw new Error("Markdown restoration probe could not restore literal delimiters");
+    await waitForText(composer, prompt, abortSignal);
+    if (JSON.stringify(await connectorState(composer)) !== JSON.stringify(connectors)) {
+      throw new Error("Markdown restoration probe changed connector state");
+    }
+    if (await page.locator(CHATGPT_USER_TURN_SELECTOR).count() !== initialUserTurns
+      || await page.locator(CHATGPT_STOP_BUTTON_SELECTOR).filter({ visible: true }).count() !== 0) {
+      throw new Error("Markdown restoration probe unexpectedly submitted a turn");
+    }
+    return true;
+  } finally {
+    composer = await activeComposer(page);
+    await clearChatGptComposerInput(composer);
+    if (await editableText(composer) !== "") throw new Error("Markdown restoration probe could not clear the composer");
+    if ((await connectorState(composer)).length !== 0) {
+      throw new Error("Markdown restoration probe could not clear connector state");
+    }
+    const send = composer.locator("xpath=ancestor::form[1]").getByTestId("send-button");
+    if (await send.isEnabled().catch(() => false)
+      || await page.locator(CHATGPT_USER_TURN_SELECTOR).count() !== initialUserTurns) {
+      throw new Error("Markdown restoration probe cleanup left submittable content");
+    }
+  }
+}

--- a/scripts/lifecycle-smoke/web-contract-core.ts
+++ b/scripts/lifecycle-smoke/web-contract-core.ts
@@ -1,4 +1,5 @@
 export const WEB_CONTRACT_COOLDOWN_MS = 2 * 60_000;
+export const WEB_CONTRACT_PROBE_TIMEOUT_MS = 5 * 60_000;
 export const WEB_CONTRACT_TURN_TIMEOUT_MS = 3 * 60_000;
 
 const capabilityKeys = [
@@ -7,6 +8,7 @@ const capabilityKeys = [
   "composer",
   "effort",
   "connector",
+  "markdownRestoration",
   "submitted",
   "finalProjection",
   "browserIdle",
@@ -37,6 +39,7 @@ export function captureWebContract(source: Record<string, unknown>): WebContract
 export function deriveWebContractCapabilities(evidence: {
   session: { authenticated: boolean; temporary: boolean; composer: boolean; solAvailable?: boolean };
   connectorVerified: boolean;
+  markdownRestoration: boolean;
   responseAccepted: boolean;
   finalProjection: boolean;
   browserIdle: boolean;
@@ -47,6 +50,7 @@ export function deriveWebContractCapabilities(evidence: {
     composer: evidence.session.composer,
     effort: evidence.session.solAvailable === true,
     connector: evidence.connectorVerified,
+    markdownRestoration: evidence.markdownRestoration,
     submitted: evidence.responseAccepted,
     finalProjection: evidence.finalProjection,
     browserIdle: evidence.browserIdle,

--- a/scripts/lifecycle-smoke/web-contract.ts
+++ b/scripts/lifecycle-smoke/web-contract.ts
@@ -1,11 +1,17 @@
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join, resolve } from "node:path";
-import { detectChatGptAccountCapabilities, isTemporaryChatGptUrl } from "../../src/chatgpt-session";
+import {
+  CHATGPT_TEMPORARY_CHAT_URL,
+  detectChatGptAccountCapabilities,
+  isTemporaryChatGptUrl,
+} from "../../src/chatgpt-session";
 import { loadConfig } from "../../src/config";
 import { VERSION } from "../../src/version";
 import {
   connectLauncherBrowserHost,
   inspectLauncherBrowserHost,
+  LAUNCHER_TURN_HEARTBEAT_INTERVAL_MS,
+  notifyLauncherTurn,
   verifyLauncherBrowserConnector,
 } from "../../src/launcher-browser-host";
 import {
@@ -14,9 +20,11 @@ import {
   deriveWebContractCapabilities,
   requestWebContractTurn,
   responseHasFinalProjection,
+  WEB_CONTRACT_PROBE_TIMEOUT_MS,
   WEB_CONTRACT_TURN_TIMEOUT_MS,
   webContractBrowserIsIdle,
 } from "./web-contract-core";
+import { runMarkdownRestorationProbe } from "./markdown-restoration-probe";
 
 const repo = resolve(import.meta.dir, "..", "..");
 const artifactDir = join(repo, "tmp", "lifecycle-smoke", "web-contract");
@@ -57,6 +65,9 @@ const config = loadConfig();
 if (config.browserHost !== "launcher" || !config.browserHostDescriptorPath) {
   throw new Error("Web contract smoke requires the launcher-owned browser host");
 }
+if (config.browserInteractionMode !== "automatic") {
+  throw new Error("Web contract smoke requires Automatic interaction mode");
+}
 if (!config.useEnhancedWebSessionMode) {
   throw new Error("Web contract smoke requires Enhanced Web Session so connector selection is exercised");
 }
@@ -77,12 +88,52 @@ const inspected = await inspectLauncherBrowserHost(config.browserHostDescriptorP
   detectCapabilities: false,
   expectedProfile: "production",
 });
-const connection = await connectLauncherBrowserHost(config.browserHostDescriptorPath);
+const probeTraceId = `web_contract_probe_${crypto.randomUUID().replaceAll("-", "")}`;
+const lease = await notifyLauncherTurn(config.browserHostDescriptorPath, {
+  phase: "start",
+  traceId: probeTraceId,
+  helperPid: process.pid,
+  connectorIdentity: config.appName,
+});
+if (!lease.surfaceId) throw new Error("Web contract smoke did not receive an Automatic turn surface");
+const connection = await connectLauncherBrowserHost(
+  config.browserHostDescriptorPath,
+  20_000,
+  lease.surfaceId,
+);
 let account;
+let markdownRestoration = false;
+let probeStatus: "completed" | "failed" = "completed";
+const heartbeat = setInterval(() => {
+  void notifyLauncherTurn(config.browserHostDescriptorPath!, {
+    phase: "heartbeat",
+    traceId: probeTraceId,
+    helperPid: process.pid,
+  }).catch(() => {});
+}, LAUNCHER_TURN_HEARTBEAT_INTERVAL_MS);
+heartbeat.unref?.();
 try {
+  await connection.page.goto(CHATGPT_TEMPORARY_CHAT_URL, { waitUntil: "domcontentloaded", timeout: 30_000 });
   account = await detectChatGptAccountCapabilities(connection.page);
+  process.stdout.write("WEB_CONTRACT_MARKDOWN_PROBE_STARTED\n");
+  markdownRestoration = await runMarkdownRestorationProbe(
+    connection.page,
+    config.appName,
+    AbortSignal.timeout(WEB_CONTRACT_PROBE_TIMEOUT_MS),
+  );
+  process.stdout.write("WEB_CONTRACT_MARKDOWN_PROBE_OK\n");
+} catch (error) {
+  probeStatus = "failed";
+  throw error;
 } finally {
-  await connection.browser.close();
+  clearInterval(heartbeat);
+  await connection.browser.close().catch(() => {});
+  await notifyLauncherTurn(config.browserHostDescriptorPath, {
+    phase: "end",
+    traceId: probeTraceId,
+    helperPid: process.pid,
+    status: probeStatus,
+  });
 }
 const session = { ...inspected, ...account };
 if (session.solAvailable !== true) throw new Error("Web contract smoke requires the ChatGPT effort control");
@@ -139,6 +190,7 @@ assertWebContractRuntimeVersion(await health(baseUrl), VERSION, runtimePid);
 const capture = deriveWebContractCapabilities({
   session,
   connectorVerified,
+  markdownRestoration,
   responseAccepted: result.response.ok,
   finalProjection,
   browserIdle,

--- a/scripts/smoke-candidate-web.ts
+++ b/scripts/smoke-candidate-web.ts
@@ -3,7 +3,11 @@ import { createRequire } from "node:module";
 import { join, resolve } from "node:path";
 import { type AppConfig, defaultBrokerEndpoint, loadConfig } from "../src/config";
 import { VERSION } from "../src/version";
-import { WEB_CONTRACT_TURN_TIMEOUT_MS, webContractBrowserIsIdle } from "./lifecycle-smoke/web-contract-core";
+import {
+  WEB_CONTRACT_PROBE_TIMEOUT_MS,
+  WEB_CONTRACT_TURN_TIMEOUT_MS,
+  webContractBrowserIsIdle,
+} from "./lifecycle-smoke/web-contract-core";
 
 const CONTROL_TIMEOUT_MS = 5_000;
 
@@ -99,7 +103,8 @@ async function runWebContract(env: Record<string, string | undefined>): Promise<
   });
   const exitCode = await Promise.race([
     smoke.exited,
-    Bun.sleep(WEB_CONTRACT_TURN_TIMEOUT_MS + 30_000).then(() => undefined),
+    Bun.sleep(WEB_CONTRACT_PROBE_TIMEOUT_MS + WEB_CONTRACT_TURN_TIMEOUT_MS + 30_000)
+      .then(() => undefined),
   ]);
   if (exitCode === undefined) {
     await terminate(smoke);

--- a/src/adapters/chatgpt-web/prompt-caret.ts
+++ b/src/adapters/chatgpt-web/prompt-caret.ts
@@ -56,12 +56,6 @@ export function guardChatGptPromptChunkBoundary(
   };
 }
 
-export type ChatGptPromptMarkdownRestoration = {
-  start: number;
-  end: number;
-  count: number;
-};
-
 export function previousChatGptPromptMarkdownMarker(
   text: string,
   before: number,
@@ -98,40 +92,7 @@ export function guardChatGptPromptMarkdown(text: string): {
   return { text: guarded, replacements, count: replacements.reduce((sum, value) => sum + value.count, 0) };
 }
 
-export function planChatGptPromptMarkdownRestoration(
-  text: string,
-  replacements: MarkdownReplacement[],
-  maxChars: number,
-): ChatGptPromptMarkdownRestoration[] {
-  if (!Number.isSafeInteger(maxChars) || maxChars <= 0) {
-    throw new Error("ChatGPT Markdown restoration range must be a positive integer");
-  }
-  const markers = new Set(replacements.map(replacement => replacement.marker));
-  const ranges: ChatGptPromptMarkdownRestoration[] = [];
-  let before = text.length;
-  while (before > 0) {
-    let right = -1;
-    for (let index = before - 1; index >= 0; index -= 1) {
-      if (markers.has(text[index]!)) { right = index; break; }
-    }
-    if (right < 0) break;
-    let end = right + 1;
-    while (end < text.length && RESTORATION_WHITESPACE.test(text[end] ?? "")) end += 1;
-    if (end > right + 1 && end < text.length) end += 1;
-    end = Math.min(end, before);
-    const windowStart = Math.max(0, end - maxChars);
-    let start = right;
-    let count = 0;
-    for (let index = windowStart; index <= right; index += 1) {
-      if (!markers.has(text[index]!)) continue;
-      start = Math.min(start, index);
-      count += 1;
-    }
-    ranges.push({ start, end, count });
-    before = start;
-  }
-  return ranges;
-}
+export const CHATGPT_PROMPT_MARKDOWN_RESTORATION_BATCH_SIZE = 128;
 
 export async function restoreChatGptPromptMarkdown(
   composer: Locator,
@@ -140,6 +101,9 @@ export async function restoreChatGptPromptMarkdown(
   maxChars = 16_000,
   abortSignal?: AbortSignal,
 ): Promise<boolean> {
+  if (!Number.isSafeInteger(maxChars) || maxChars <= 0) {
+    throw new Error("ChatGPT Markdown restoration range must be a positive integer");
+  }
   await composer.focus();
   let remaining = count;
   while (remaining > 0) {
@@ -149,68 +113,60 @@ export async function restoreChatGptPromptMarkdown(
       const selection = window.getSelection();
       if (!selection) return 0;
       const replacementsByMarker = new Map(input.replacements.map(value => [value.marker, value.value]));
-      const textNodes: Text[] = [];
-      const walker = document.createTreeWalker(element, NodeFilter.SHOW_TEXT);
-      for (let node = walker.nextNode(); node; node = walker.nextNode()) {
-        const parent = (node as Text).parentElement;
-        if (!parent?.closest(ignoredSelector)) textNodes.push(node as Text);
-      }
-      const clone = element.cloneNode(true) as HTMLElement;
-      clone.querySelectorAll(ignoredSelector).forEach(part => part.remove());
-      const guardedText = Array.from(clone.childNodes, child => child.textContent ?? "").join("\n");
-      if (guardedText.length <= input.maxChars) {
-        let markerCount = 0;
-        const restoredText = Array.from(guardedText, value => {
-          const replacement = replacementsByMarker.get(value);
-          if (replacement === undefined) return value;
-          markerCount += 1;
-          return replacement;
-        }).join("");
-        const firstText = textNodes[0];
-        const lastText = textNodes.at(-1);
-        if (markerCount === 0 || !firstText || !lastText) return 0;
+      const rightmostText = (node: Node): Text | undefined => {
+        if (node.nodeType === 1 && (node as Element).matches(ignoredSelector)) return undefined;
+        if (node.nodeType === 3) {
+          const text = node as Text;
+          return text.parentElement?.closest(ignoredSelector) ? undefined : text;
+        }
+        for (let child = node.lastChild; child; child = child.previousSibling) {
+          const text = rightmostText(child);
+          if (text) return text;
+        }
+        return undefined;
+      };
+      const previousText = (node: Node): Text | undefined => {
+        for (let current: Node | null = node; current && current !== element; current = current.parentNode) {
+          for (let sibling = current.previousSibling; sibling; sibling = sibling.previousSibling) {
+            const text = rightmostText(sibling);
+            if (text) return text;
+          }
+        }
+        return undefined;
+      };
+      let position = rightmostText(element);
+      let before = position?.data.length ?? 0;
+      let restored = 0;
+      // Keep the serialized Playwright input stable; maxChars remains the
+      // public mutation bound while each browser task performs at most 128 edits.
+      while (position && restored < Math.min(input.maxChars, 128)) {
+        let match: { offset: number; value: string } | undefined;
+        for (const replacement of input.replacements) {
+          const offset = position.data.lastIndexOf(replacement.marker, before - 1);
+          if (offset >= 0 && (!match || offset > match.offset)) match = { offset, value: replacement.value };
+        }
+        if (!match) {
+          position = previousText(position);
+          before = position?.data.length ?? 0;
+          continue;
+        }
         const range = document.createRange();
-        range.setStart(firstText, 0);
-        range.setEnd(lastText, lastText.data.length);
+        range.setStart(position, match.offset);
+        range.setEnd(position, match.offset + 1);
         selection.removeAllRanges();
         selection.addRange(range);
-        if (!document.execCommand("insertText", false, restoredText)) return 0;
+        if (!document.execCommand("insertText", false, match.value)) return -1;
+        restored += 1;
+        before = match.offset;
         await Promise.resolve();
-        return markerCount;
+        if (!element.contains(position)) break;
       }
-      for (let nodeIndex = textNodes.length - 1; nodeIndex >= 0; nodeIndex -= 1) {
-        const node = textNodes[nodeIndex]!;
-        let right = -1;
-        for (let index = node.data.length - 1; index >= 0; index -= 1) {
-          if (replacementsByMarker.has(node.data[index]!)) { right = index; break; }
-        }
-        if (right < 0) continue;
-        let rangeEnd = right + 1;
-        while (rangeEnd < node.data.length && /\s/u.test(node.data[rangeEnd] ?? "")) rangeEnd += 1;
-        if (rangeEnd > right + 1 && rangeEnd < node.data.length) rangeEnd += 1;
-        const windowStart = Math.max(0, rangeEnd - input.maxChars);
-        let start = right;
-        let markerCount = 0;
-        for (let index = windowStart; index <= right; index += 1) {
-          if (!replacementsByMarker.has(node.data[index]!)) continue;
-          start = Math.min(start, index);
-          markerCount += 1;
-        }
-        const guarded = node.data.slice(start, rangeEnd);
-        const restoredText = Array.from(guarded, value => replacementsByMarker.get(value) ?? value).join("");
-        const range = document.createRange();
-        range.setStart(node, start);
-        range.setEnd(node, rangeEnd);
-        selection.removeAllRanges();
-        selection.addRange(range);
-        if (!document.execCommand("insertText", false, restoredText)) return 0;
-        await new Promise<void>(resolve => setTimeout(resolve, 0));
-        return markerCount;
-      }
-      return 0;
+      return restored;
     }, { replacements, maxChars }, { timeout: 20_000 });
+    if (abortSignal?.aborted) throw abortSignal.reason ?? new DOMException("Prompt attachment aborted", "AbortError");
     if (!Number.isSafeInteger(restored) || restored <= 0 || restored > remaining) return false;
     remaining -= restored;
+    if (remaining > 0) await new Promise(resolve => setTimeout(resolve, 0));
   }
   if (abortSignal?.aborted) throw abortSignal.reason ?? new DOMException("Prompt attachment aborted", "AbortError");
   return composer.evaluate((element, markers) => {

--- a/tests/candidate-web-smoke.test.ts
+++ b/tests/candidate-web-smoke.test.ts
@@ -38,6 +38,6 @@ test("candidate Web smoke drains before shutdown and bounds the live subprocess"
   const shutdownAt = script.indexOf('control(baseUrl, "shutdown"');
   expect(drainAt).toBeGreaterThan(-1);
   expect(shutdownAt).toBeGreaterThan(drainAt);
-  expect(script).toContain("WEB_CONTRACT_TURN_TIMEOUT_MS + 30_000");
+  expect(script).toContain("WEB_CONTRACT_PROBE_TIMEOUT_MS + WEB_CONTRACT_TURN_TIMEOUT_MS + 30_000");
   expect(script).toContain("Candidate Web smoke timed out");
 });

--- a/tests/prompt-markdown-restoration.test.ts
+++ b/tests/prompt-markdown-restoration.test.ts
@@ -1,45 +1,21 @@
 import { expect, test } from "bun:test";
 import {
+  CHATGPT_PROMPT_MARKDOWN_RESTORATION_BATCH_SIZE,
   guardChatGptPromptMarkdown,
-  planChatGptPromptMarkdownRestoration,
   restoreChatGptPromptMarkdown,
 } from "../src/adapters/chatgpt-web/prompt-caret";
 
-test("plans incident-sized Markdown restoration in bounded text ranges", () => {
-  const pattern = "field_name=value) [literal](target) `code` *bold* ~=~ ";
-  const prompt = pattern.repeat(Math.ceil(93_255 / pattern.length)).slice(0, 93_255);
-  const guarded = guardChatGptPromptMarkdown(prompt);
-
-  expect(guarded).toBeDefined();
-  expect(guarded!.count).toBeGreaterThan(2_484);
-  const ranges = planChatGptPromptMarkdownRestoration(
-    guarded!.text,
-    guarded!.replacements,
-    16_000,
-  );
-
-  expect(ranges.length).toBeLessThanOrEqual(Math.ceil(prompt.length / 16_000) + 1);
-  expect(ranges.every(range => range.end - range.start <= 16_000)).toBeTrue();
-  expect(ranges.reduce((count, range) => count + range.count, 0)).toBe(guarded!.count);
-  expect(ranges.every((range, index) => index === 0 || range.end <= ranges[index - 1]!.start)).toBeTrue();
+test("guards every literal Markdown delimiter without changing prompt length", () => {
+  const prompt = "field_name=value) [literal](target) `code` *bold* ~=~";
+  const guarded = guardChatGptPromptMarkdown(prompt)!;
+  expect(guarded.text).toHaveLength(prompt.length);
+  expect(guarded.count).toBe(12);
+  expect(guarded.replacements.map(replacement => replacement.value)).toEqual([
+    "`", "*", "_", "~", "=", "[", ")",
+  ]);
 });
 
-test("restoration planning ignores unguarded text and rejects invalid bounds", () => {
-  expect(planChatGptPromptMarkdownRestoration("plain text", [], 16_000)).toEqual([]);
-  expect(() => planChatGptPromptMarkdownRestoration("\uE000", [
-    { marker: "\uE000", value: "*", count: 1 },
-  ], 0)).toThrow("positive");
-});
-
-test("restoration ranges carry trailing whitespace with one following code unit", () => {
-  expect(planChatGptPromptMarkdownRestoration(
-    "a\uE000 word",
-    [{ marker: "\uE000", value: "*", count: 1 }],
-    8,
-  )).toEqual([{ start: 1, end: 4, count: 1 }]);
-});
-
-test("restores a short multi-block prompt in one editor mutation", async () => {
+test("restores a short multi-block prompt without selecting its connector", async () => {
   const { createDocument } = require("@mixmark-io/domino") as {
     createDocument: (html: string) => Document;
   };
@@ -101,7 +77,10 @@ test("restores a short multi-block prompt in one editor mutation", async () => {
     expect(connector).not.toBeNull();
     expect(connector.contains(selected.startNode ?? null)).toBeFalse();
     expect(connector.contains(selected.endNode ?? null)).toBeFalse();
-    expect(composerElement.lastChild?.textContent).toBe("A`one`\nB*two*\nC_three_");
+    expect(Array.from(composerElement.children)
+      .filter(child => !child.matches('[data-id^="plugin:"][data-keyword]'))
+      .map(child => child.textContent ?? "")
+      .join("\n")).toBe("A`one`\nB*two*\nC_three_");
   } finally {
     Object.assign(globalThis, {
       window: previousWindow,
@@ -127,15 +106,19 @@ test("restores an incident-sized Markdown prompt without bulk Lexical replacemen
   const composerElement = document.getElementById("composer")!;
   composerElement.appendChild(document.createTextNode(guarded.text));
   let selected: { node?: Text; start?: number; end?: number } = {};
+  let currentBatchOperations = 0;
+  const batchOperations: number[] = [];
   document.createRange = () => ({
     setStart: (node: Text, offset: number) => { selected = { node, start: offset }; },
     setEnd: (node: Text, offset: number) => { selected.end = offset; },
   } as unknown as Range);
   let maxReplacementChars = 0;
   document.execCommand = (_command, _showUi, value) => {
-    maxReplacementChars = Math.max(maxReplacementChars, value.length);
-    if (value.length !== 1 || !selected.node) return false;
-    selected.node.data = `${selected.node.data.slice(0, selected.start)}${value}${selected.node.data.slice(selected.end)}`;
+    const replacement = value ?? "";
+    currentBatchOperations += 1;
+    maxReplacementChars = Math.max(maxReplacementChars, replacement.length);
+    if (replacement.length !== 1 || !selected.node) return false;
+    selected.node.data = `${selected.node.data.slice(0, selected.start)}${replacement}${selected.node.data.slice(selected.end)}`;
     return true;
   };
   const previousWindow = globalThis.window;
@@ -147,11 +130,20 @@ test("restores an incident-sized Markdown prompt without bulk Lexical replacemen
     window: { getSelection: () => ({ removeAllRanges: () => {}, addRange: () => {} }) },
   });
   let evaluateCalls = 0;
+  let remounted = false;
   const composer = {
     focus: async () => {},
     evaluate: async (callback: (element: HTMLElement, input: unknown) => unknown, input: unknown) => {
       evaluateCalls += 1;
-      return await callback(composerElement, input);
+      currentBatchOperations = 0;
+      const result = await callback(composerElement, input);
+      batchOperations.push(currentBatchOperations);
+      if (!remounted && currentBatchOperations === CHATGPT_PROMPT_MARKDOWN_RESTORATION_BATCH_SIZE) {
+        const current = composerElement.lastChild!;
+        composerElement.replaceChild(current.cloneNode(true), current);
+        remounted = true;
+      }
+      return result;
     },
   };
 
@@ -165,7 +157,9 @@ test("restores an incident-sized Markdown prompt without bulk Lexical replacemen
     )).resolves.toBeTrue();
     expect(composerElement.lastChild?.textContent).toBe(prompt);
     expect(maxReplacementChars).toBe(1);
-    expect(evaluateCalls).toBeGreaterThan(2);
+    expect(remounted).toBeTrue();
+    expect(evaluateCalls).toBe(Math.ceil(guarded.count / CHATGPT_PROMPT_MARKDOWN_RESTORATION_BATCH_SIZE) + 1);
+    expect(Math.max(...batchOperations)).toBe(CHATGPT_PROMPT_MARKDOWN_RESTORATION_BATCH_SIZE);
   } finally {
     Object.assign(globalThis, {
       window: previousWindow,
@@ -173,4 +167,35 @@ test("restores an incident-sized Markdown prompt without bulk Lexical replacemen
       NodeFilter: previousNodeFilter,
     });
   }
+});
+
+test("fails closed for invalid restoration progress and stops after abort", async () => {
+  const replacement = [{ marker: "\u2060", value: "`", count: 1 }];
+  for (const progress of [[0], [-1], [2], [1, false]] as const) {
+    let call = 0;
+    const composer = {
+      focus: async () => {},
+      evaluate: async () => progress[call++],
+    };
+    await expect(restoreChatGptPromptMarkdown(composer as never, replacement, 1)).resolves.toBeFalse();
+  }
+
+  const controller = new AbortController();
+  let calls = 0;
+  const composer = {
+    focus: async () => {},
+    evaluate: async () => {
+      calls += 1;
+      controller.abort(new Error("cancelled"));
+      return CHATGPT_PROMPT_MARKDOWN_RESTORATION_BATCH_SIZE;
+    },
+  };
+  await expect(restoreChatGptPromptMarkdown(
+    composer as never,
+    replacement,
+    CHATGPT_PROMPT_MARKDOWN_RESTORATION_BATCH_SIZE + 1,
+    16_000,
+    controller.signal,
+  )).rejects.toThrow("cancelled");
+  expect(calls).toBe(1);
 });

--- a/tests/prompt-markdown-restoration.test.ts
+++ b/tests/prompt-markdown-restoration.test.ts
@@ -110,3 +110,67 @@ test("restores a short multi-block prompt in one editor mutation", async () => {
     });
   }
 });
+
+test("restores an incident-sized Markdown prompt without bulk Lexical replacement", async () => {
+  const { createDocument } = require("@mixmark-io/domino") as {
+    createDocument: (html: string) => Document;
+  };
+  const pattern = "field_name=value) [literal](target) `code` *bold* ~=~ payload ";
+  const prompt = pattern.repeat(Math.ceil(17_587 / pattern.length)).slice(0, 17_587);
+  const guarded = guardChatGptPromptMarkdown(prompt)!;
+  const document = createDocument(
+    '<div id="composer"><span data-id="plugin:test" data-keyword="Codex Native2">Codex Native2</span></div>',
+  ) as Document & {
+    createRange: () => Range;
+    execCommand: (command: string, showUi: boolean, value: string) => boolean;
+  };
+  const composerElement = document.getElementById("composer")!;
+  composerElement.appendChild(document.createTextNode(guarded.text));
+  let selected: { node?: Text; start?: number; end?: number } = {};
+  document.createRange = () => ({
+    setStart: (node: Text, offset: number) => { selected = { node, start: offset }; },
+    setEnd: (node: Text, offset: number) => { selected.end = offset; },
+  } as unknown as Range);
+  let maxReplacementChars = 0;
+  document.execCommand = (_command, _showUi, value) => {
+    maxReplacementChars = Math.max(maxReplacementChars, value.length);
+    if (value.length !== 1 || !selected.node) return false;
+    selected.node.data = `${selected.node.data.slice(0, selected.start)}${value}${selected.node.data.slice(selected.end)}`;
+    return true;
+  };
+  const previousWindow = globalThis.window;
+  const previousDocument = globalThis.document;
+  const previousNodeFilter = globalThis.NodeFilter;
+  Object.assign(globalThis, {
+    document,
+    NodeFilter: { SHOW_TEXT: 4 },
+    window: { getSelection: () => ({ removeAllRanges: () => {}, addRange: () => {} }) },
+  });
+  let evaluateCalls = 0;
+  const composer = {
+    focus: async () => {},
+    evaluate: async (callback: (element: HTMLElement, input: unknown) => unknown, input: unknown) => {
+      evaluateCalls += 1;
+      return await callback(composerElement, input);
+    },
+  };
+
+  try {
+    expect(guarded.count).toBeGreaterThan(3_000);
+    await expect(restoreChatGptPromptMarkdown(
+      composer as never,
+      guarded.replacements,
+      guarded.count,
+      16_000,
+    )).resolves.toBeTrue();
+    expect(composerElement.lastChild?.textContent).toBe(prompt);
+    expect(maxReplacementChars).toBe(1);
+    expect(evaluateCalls).toBeGreaterThan(2);
+  } finally {
+    Object.assign(globalThis, {
+      window: previousWindow,
+      document: previousDocument,
+      NodeFilter: previousNodeFilter,
+    });
+  }
+});

--- a/tests/web-contract-smoke.test.ts
+++ b/tests/web-contract-smoke.test.ts
@@ -8,13 +8,22 @@ import {
   requestWebContractTurn,
   responseHasFinalProjection,
   WEB_CONTRACT_COOLDOWN_MS,
+  WEB_CONTRACT_PROBE_TIMEOUT_MS,
   WEB_CONTRACT_TURN_TIMEOUT_MS,
   webContractBrowserIsIdle,
 } from "../scripts/lifecycle-smoke/web-contract-core";
+import {
+  markdownRestorationProbeText,
+  MARKDOWN_RESTORATION_PROBE_CHARS,
+} from "../scripts/lifecycle-smoke/markdown-restoration-probe";
+import { guardChatGptPromptMarkdown } from "../src/adapters/chatgpt-web/prompt-caret";
 
 describe("lightweight Web contract smoke", () => {
   test("uses the requested Medium route without model fallback", () => {
-    const script = readFileSync(new URL("../scripts/lifecycle-smoke/web-contract.ts", import.meta.url), "utf8");
+    const script = readFileSync(
+      new URL("../scripts/lifecycle-smoke/web-contract.ts", import.meta.url),
+      "utf8",
+    ).replaceAll("\r\n", "\n");
     expect(script).toContain('model: "chatgpt-web/medium"');
     expect(script).toContain('reasoning: { effort: "medium" }');
     expect(script).not.toContain("session.proAvailable !== true");
@@ -22,7 +31,10 @@ describe("lightweight Web contract smoke", () => {
     expect(script).not.toContain('model: "chatgpt-web/extra-high"');
   });
   test("refreshes once for connector verification before inspecting the hydrated surface", () => {
-    const script = readFileSync(new URL("../scripts/lifecycle-smoke/web-contract.ts", import.meta.url), "utf8");
+    const script = readFileSync(
+      new URL("../scripts/lifecycle-smoke/web-contract.ts", import.meta.url),
+      "utf8",
+    ).replaceAll("\r\n", "\n");
     const verifyAt = script.indexOf("const connectorVerified = await verifyLauncherBrowserConnector");
     const inspectAt = script.indexOf("const inspected = await inspectLauncherBrowserHost");
     const cooldownAt = script.indexOf("writeFileSync(lastRunPath");
@@ -32,6 +44,36 @@ describe("lightweight Web contract smoke", () => {
     expect(inspectAt).toBeGreaterThan(verifyAt);
     expect(script).toContain("detectCapabilities: false");
     expect(script).toContain("detectChatGptAccountCapabilities(connection.page)");
+    expect(script).toContain("runMarkdownRestorationProbe(");
+    expect(script).toContain("connection.page,\n    config.appName,");
+    expect(script).toContain('config.browserInteractionMode !== "automatic"');
+    expect(script).toContain('phase: "start"');
+    expect(script).toContain("lease.surfaceId");
+    expect(script).toContain('phase: "end"');
+  });
+
+  test("uses the incident-sized Markdown probe without sending its contents", () => {
+    const prompt = markdownRestorationProbeText();
+    const guarded = guardChatGptPromptMarkdown(prompt)!;
+    const probe = readFileSync(
+      new URL("../scripts/lifecycle-smoke/markdown-restoration-probe.ts", import.meta.url),
+      "utf8",
+    );
+    expect(prompt).toHaveLength(MARKDOWN_RESTORATION_PROBE_CHARS);
+    expect(prompt[16_000]).toBe(" ");
+    expect(guarded.count).toBe(3_402);
+    expect(probe).toContain("finally {");
+    expect(probe).toContain("clearChatGptComposerInput(composer)");
+    expect(probe.indexOf("await clearChatGptComposerInput(composer)"))
+      .toBeLessThan(probe.indexOf("composer = await selectConnector(page, appName)"));
+    expect(probe.indexOf("await composer.focus()"))
+      .toBeLessThan(probe.indexOf("await page.keyboard.insertText(chunk)"));
+    expect(probe).toContain("CHATGPT_USER_TURN_SELECTOR");
+    expect(probe).toContain('pressSequentially("@codex"');
+    expect(probe).toContain("MAX_CHATGPT_CONNECTOR_TRIGGER_ATTEMPTS");
+    expect(probe).toContain("unexpectedly submitted a turn");
+    expect(probe).toContain("could not clear connector state");
+    expect(probe).toContain("cleanup left submittable content");
   });
 
   test("captures only allowlisted semantic capabilities", () => {
@@ -41,6 +83,7 @@ describe("lightweight Web contract smoke", () => {
       composer: true,
       effort: true,
       connector: true,
+      markdownRestoration: true,
       submitted: true,
       finalProjection: true,
       browserIdle: true,
@@ -55,6 +98,7 @@ describe("lightweight Web contract smoke", () => {
       composer: true,
       effort: true,
       connector: true,
+      markdownRestoration: true,
       submitted: true,
       finalProjection: true,
       browserIdle: true,
@@ -67,6 +111,7 @@ describe("lightweight Web contract smoke", () => {
     expect(deriveWebContractCapabilities({
       session: { authenticated: true, temporary: true, composer: true, solAvailable: true },
       connectorVerified: false,
+      markdownRestoration: true,
       responseAccepted: true,
       finalProjection: false,
       browserIdle: true,
@@ -76,6 +121,7 @@ describe("lightweight Web contract smoke", () => {
       composer: true,
       effort: true,
       connector: false,
+      markdownRestoration: true,
       submitted: true,
       finalProjection: false,
       browserIdle: true,
@@ -142,10 +188,15 @@ describe("lightweight Web contract smoke", () => {
   });
 
   test("checks the same live runtime process before and after the account-bound turn", () => {
-    const script = readFileSync(new URL("../scripts/lifecycle-smoke/web-contract.ts", import.meta.url), "utf8");
+    const script = readFileSync(
+      new URL("../scripts/lifecycle-smoke/web-contract.ts", import.meta.url),
+      "utf8",
+    ).replaceAll("\r\n", "\n");
     expect(script.match(/assertWebContractRuntimeVersion\(/g)).toHaveLength(2);
     expect(script).toContain("runtimePid");
     expect(WEB_CONTRACT_TURN_TIMEOUT_MS).toBe(180_000);
+    expect(WEB_CONTRACT_PROBE_TIMEOUT_MS).toBe(300_000);
+    expect(script).toContain("AbortSignal.timeout(WEB_CONTRACT_PROBE_TIMEOUT_MS)");
     expect(script).toContain("AbortSignal.timeout(WEB_CONTRACT_TURN_TIMEOUT_MS)");
     expect(script).toContain("**bold**, `code`, and _emphasis_");
   });


### PR DESCRIPTION
## Summary
- replace guarded Markdown markers one at a time so Lexical never receives thousands of literal delimiters in one native edit
- yield after at most 128 replacements and re-resolve the live composer across remounts
- add a local release gate that restores and clears a 17,587-character, 3,402-delimiter payload without submitting it before the existing Medium Web turn

## Safety
- fail closed on missing markers, invalid progress, aborts, residual markers, or cleanup failures
- preserve connector state through restoration and prove no user turn is created
- leave Zero Risk runtime and MCP behavior unchanged

## Verification
- pinned Bun 1.4.0+34cbb9a40
- focused restoration, browser worker, candidate Web and contract tests passed
- bounded root suite and launcher suite passed
- root and launcher typechecks passed
- audits, version, license, deterministic lifecycle all lane, runtime bundle/smoke, renderer build, Windows package and packaged-app smoke passed
- verify:release passed against the exact candidate, including the live 17,587-character restoration probe and one Automatic Medium turn

Independent review covered launcher ownership, real connector selection, and no-send proof; all findings were addressed.