### PR TITLE
test: stabilize browser failure rejection observation

### DIFF
--- a/tests/browser-token-lifecycle.test.ts
+++ b/tests/browser-token-lifecycle.test.ts
@@ -120,9 +120,15 @@ test("a browser failure remains the authoritative turn error while its token is 
 
   try {
     const running = createChatGptWebAdapter(provider).runTurn!(request(), { headers: new Headers() }, () => {});
+    const outcome = running.then(
+      () => ({ error: undefined }),
+      error => ({ error }),
+    );
     await Bun.sleep(10);
     failSurface(new Error("browser surface closed"));
-    await expect(running).rejects.toThrow("browser surface closed");
+    const { error } = await outcome;
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toBe("browser surface closed");
   } finally {
     (worker as unknown as { run: (turn: BrowserTurn) => Promise<string> }).run = originalRun;
     await broker.close();


### PR DESCRIPTION
## Summary

- attach the expected browser-turn rejection observer before triggering the synthetic surface failure
- preserve the authoritative browser error and token-revocation behavior
- change no production, timeout, or Zero Risk code

## Evidence

- captured RED: merge-after-main Windows CI run 33973024185 reported the rejection as unhandled
- focused case repeated 25 times with pinned Bun 1.4.0
- bounded root suite: 213 files passed
- launcher suite: 452 passed, 1 platform skip
- root and launcher typechecks passed
- exact-candidate verify:release passed, including the 17.6k Markdown restoration probe and one Automatic Medium live turn
