### PR TITLE
test: bound the v5.0.1 audit archive check

### DIFF
--- a/tests/upstream-audit-v501-ledger.test.ts
+++ b/tests/upstream-audit-v501-ledger.test.ts
@@ -65,7 +65,7 @@ test("v5.0.1 ledger pins the exact release and contemporaneous merge evidence", 
   expect(archivedTag.stdout).toStartWith(`object ${ledger.upstream.commit}\ntype commit\ntag ${ledger.release}\n`);
   expect(ledger.mergeEvidence.kind).toBe("contemporaneous-default-ort");
   expect(ledger.mergeEvidence.inheritedLimitation).toContain("v5.0.0");
-});
+}, 15_000);
 
 test("v5.0.1 public evidence archive is complete and excludes private state", () => {
   const archive = resolve(root, ledger.mergeEvidence.archive);


### PR DESCRIPTION
## Summary

- give the Windows tar/Git publication-evidence check an explicit 15-second test budget
- retain every existing archive, tag, hash, and mapping assertion
- change no production or Zero Risk timeout

## Evidence

- captured RED: main Windows CI run 33975241246 exceeded Bun's default 5-second test timeout while extracting the public v5.0.1 evidence archive
- focused archive check repeated 10 times with pinned Bun 1.4.0
- complete v5.0.1 ledger test passed
- exact-candidate verify:release passed, including the 17.6k Markdown restoration probe and one Automatic Medium live turn
