### PR TITLE
test: start MCP deadlines after transport setup

### DIFF
--- a/tests/chatgpt-web-harness.test.ts
+++ b/tests/chatgpt-web-harness.test.ts
@@ -17,7 +17,7 @@ import { chatGptReadOnlyContextWarning, compileChatGptWebPrompt, withoutSupersed
 import { MAX_CHATGPT_WEB_TURN_RETRIES } from "../src/adapters/chatgpt-web/retry-policy";
 import { ChatGptTextFeed, ChatGptTraceFeed, ChatGptTurnSessions, chatGptCompactionSourceExecutionKey, chatGptConversationKey, chatGptTurnExecutionKey, chatGptTurnSessions } from "../src/adapters/chatgpt-web/turn-execution";
 import { callTurnBroker, TurnBroker, type BrokerToolResult } from "../src/adapters/chatgpt-web/turn-broker";
-import { ChatGptExternalTurnProgress, ChatGptMirroredTurnProgress, chatGptExternalProgressIsLive, chatGptExternalToolCallsAreInFlight } from "../src/adapters/chatgpt-web/turn-progress";
+import { ChatGptExternalTurnProgress, ChatGptMirroredTurnProgress, chatGptExternalProgressIsLive } from "../src/adapters/chatgpt-web/turn-progress";
 import { CHATGPT_WEB_MCP_INVOCATION_TIMEOUT_MS, chatGptMcpInvocationTimeout } from "../src/adapters/chatgpt-web/mcp-server";
 import { defaultBrokerEndpoint } from "../src/config";
 import { estimateChatGptWebUsage } from "../src/adapters/chatgpt-web/usage";
@@ -2848,81 +2848,6 @@ describe("ChatGPT outer-native harness v4", () => {
     } finally {
       await client.close().catch(() => {});
       broker.revoke(abandonedToken);
-      broker.revoke(replacementToken);
-      await broker.close();
-    }
-  }, 10_000);
-
-  test("a native tool deadline returns an explicit MCP timeout instead of a transport failure", async () => {
-    const socketPath = brokerTestEndpoint(`cgw-h3-mcp-timeout-${process.pid}-${Date.now()}`);
-    const broker = TurnBroker.forSocket(socketPath);
-    const environment = extractChatGptTurnEnvironment(parsed(environmentXml));
-    environment.tools = [
-      { name: "exec_command", description: "Run a Codex command", parameters: { type: "object" } },
-    ];
-    const timedOutToken = await broker.register(environment, 1_500, "timeout-turn");
-    const replacementToken = await broker.register(environment, undefined, "replacement-turn");
-    const transport = new StdioClientTransport({
-      command: process.execPath,
-      args: ["src/cli.ts", "mcp", "--broker-socket", socketPath],
-      cwd: process.cwd(),
-      stderr: "pipe",
-    });
-    const client = new Client({ name: "codex-chatgpt-web-mcp-timeout-test", version: "1.0.0" });
-
-    try {
-      await client.connect(transport);
-      const timedOut = client.callTool({
-        name: "codex_exec",
-        arguments: { turn_token: timedOutToken, cmd: "slow external MCP call" },
-      });
-      const [request] = await broker.nextToolBatch(timedOutToken);
-      expect(request).toMatchObject({ wireName: "exec_command" });
-      const externalProgress = new ChatGptExternalTurnProgress();
-      const toolBatchRevision = externalProgress.recordToolBatch(1, 1_000);
-      const toolBoundary = externalProgress.waitForToolBatchObservation(toolBatchRevision);
-      const pendingAdapterBatch = toolBoundary.then(() => request);
-      const pendingAdapterBatchOutcome = pendingAdapterBatch.then(
-        value => ({ type: "value" as const, value }),
-        error => ({ type: "error" as const, error: error instanceof Error ? error : new Error(String(error)) }),
-      );
-      const retirement = broker.waitForRetirement(timedOutToken).then(() => {
-        externalProgress.retire(new Error("MCP invocation retired its turn binding"));
-      });
-
-      const timeoutResult = await timedOut;
-      expect(timeoutResult.isError).toBe(true);
-      expect(timeoutResult.structuredContent).toMatchObject({
-        code: "codex_tool_timeout",
-        tool: "exec_command",
-        retryable: false,
-      });
-      expect(JSON.stringify(timeoutResult.content)).toContain("did not complete before the MCP transport deadline");
-      await retirement;
-      expect(externalProgress.snapshot().activeToolCalls).toBe(0);
-      expect(chatGptExternalToolCallsAreInFlight(externalProgress.snapshot())).toBeFalse();
-      const batchOutcome = await pendingAdapterBatchOutcome;
-      expect(batchOutcome.type).toBe("error");
-      if (batchOutcome.type !== "error") throw new Error("retired tool batch crossed its browser boundary");
-      expect(batchOutcome.error.message).toContain("retired its turn binding");
-      expect(() => externalProgress.recordToolResult()).toThrow("retired its turn binding");
-
-      await expect(callTurnBroker(socketPath, { method: "claim", token: timedOutToken }))
-        .rejects.toThrow("already finished");
-      expect(() => broker.completeTool(timedOutToken, request!.callId, toolResult({ output: "late" })))
-        .toThrow("turn token is invalid or expired");
-
-      const inventory = await client.callTool({
-        name: "codex_tool_inventory",
-        arguments: { turn_token: replacementToken, query: "exec_command", include_schema: false },
-      });
-      expect(inventory.structuredContent).toMatchObject({
-        total: 1,
-        tools: [{ wire_name: "exec_command" }],
-      });
-    } finally {
-      await client.close().catch(() => {});
-      broker.revoke(timedOutToken);
       broker.revoke(replacementToken);
       await broker.close();
     }

--- a/tests/native-tool-evidence.test.ts
+++ b/tests/native-tool-evidence.test.ts
@@ -6,6 +6,10 @@ import { join } from "node:path";
 import { compileChatGptWebPrompt } from "../src/adapters/chatgpt-web/prompt";
 import { readTextFileCommand } from "../src/adapters/chatgpt-web/native-command";
 import { callTurnBroker, TurnBroker } from "../src/adapters/chatgpt-web/turn-broker";
+import {
+  ChatGptExternalTurnProgress,
+  chatGptExternalToolCallsAreInFlight,
+} from "../src/adapters/chatgpt-web/turn-progress";
 import { CHATGPT_WEB_MODEL_ID } from "../src/adapters/chatgpt-web/model";
 import { defaultBrokerEndpoint } from "../src/config";
 import type { ChatGptTurnEnvironment } from "../src/adapters/chatgpt-web/environment";
@@ -14,6 +18,7 @@ import {
   chatGptMcpInvocationTimeout,
 } from "../src/adapters/chatgpt-web/mcp-server";
 import type { CodexParsedRequest } from "../src/types";
+import { toolResult } from "./chatgpt-harness-fixture";
 
 const evidenceContract = "Describe failed local actions using only observable tool evidence. If no native result was returned, state only that the action did not execute; never infer or name an unreported cause.";
 const safeDiscoveryContract = "__codex_tool_search__:<capability query>";
@@ -194,6 +199,80 @@ test("an aborted MCP request revokes only its turn binding and leaves the server
     await client.close().catch(() => {});
     broker.revoke(abandonedToken);
     broker.revoke(replacementToken);
+    await broker.close();
+  }
+}, 10_000);
+
+test("a native tool deadline starts after MCP transport setup and retires its browser boundary", async () => {
+  const socketPath = brokerEndpoint(`cgw-native-timeout-${process.pid}-${Date.now()}`);
+  const broker = TurnBroker.forSocket(socketPath);
+  const environment: ChatGptTurnEnvironment = {
+    cwd: process.cwd(),
+    roots: [process.cwd()],
+    writableRoots: [process.cwd()],
+    sandboxPolicy: { type: "dangerFullAccess" },
+    tools: [{ name: "exec_command", description: "Run a command", parameters: { type: "object" } }],
+  };
+  const client = new Client({ name: "native-timeout-test", version: "1.0.0" });
+  const tokens: string[] = [];
+
+  try {
+    await client.connect(new StdioClientTransport({
+      command: process.execPath,
+      args: ["src/cli.ts", "mcp", "--broker-socket", socketPath],
+      cwd: process.cwd(),
+      stderr: "pipe",
+    }));
+    const timedOutToken = await broker.register(environment, 1_500, "timeout-turn");
+    const replacementToken = await broker.register(environment, undefined, "replacement-turn");
+    tokens.push(timedOutToken, replacementToken);
+
+    const timedOut = client.callTool({
+      name: "codex_exec",
+      arguments: { turn_token: timedOutToken, cmd: "slow external MCP call" },
+    });
+    const [request] = await broker.nextToolBatch(timedOutToken);
+    expect(request).toMatchObject({ wireName: "exec_command" });
+    const externalProgress = new ChatGptExternalTurnProgress();
+    const revision = externalProgress.recordToolBatch(1, 1_000);
+    const pendingBatch = externalProgress.waitForToolBatchObservation(revision).then(() => request);
+    const batchOutcome = pendingBatch.then(
+      value => ({ type: "value" as const, value }),
+      error => ({ type: "error" as const, error: error instanceof Error ? error : new Error(String(error)) }),
+    );
+    const retirement = broker.waitForRetirement(timedOutToken).then(() => {
+      externalProgress.retire(new Error("MCP invocation retired its turn binding"));
+    });
+
+    const timeoutResult = await timedOut;
+    expect(timeoutResult.isError).toBe(true);
+    expect(timeoutResult.structuredContent).toMatchObject({
+      code: "codex_tool_timeout",
+      tool: "exec_command",
+      retryable: false,
+    });
+    expect(JSON.stringify(timeoutResult.content)).toContain("did not complete before the MCP transport deadline");
+    await retirement;
+    expect(externalProgress.snapshot().activeToolCalls).toBe(0);
+    expect(chatGptExternalToolCallsAreInFlight(externalProgress.snapshot())).toBeFalse();
+    const settledBatch = await batchOutcome;
+    expect(settledBatch.type).toBe("error");
+    if (settledBatch.type !== "error") throw new Error("retired tool batch crossed its browser boundary");
+    expect(settledBatch.error.message).toContain("retired its turn binding");
+    expect(() => externalProgress.recordToolResult()).toThrow("retired its turn binding");
+    await expect(callTurnBroker(socketPath, { method: "claim", token: timedOutToken }))
+      .rejects.toThrow("already finished");
+    expect(() => broker.completeTool(timedOutToken, request!.callId, toolResult({ output: "late" })))
+      .toThrow("turn token is invalid or expired");
+
+    const inventory = await client.callTool({
+      name: "codex_tool_inventory",
+      arguments: { turn_token: replacementToken, query: "exec_command", include_schema: false },
+    });
+    expect(inventory.structuredContent).toMatchObject({ total: 1, tools: [{ wire_name: "exec_command" }] });
+  } finally {
+    await client.close().catch(() => {});
+    for (const token of tokens) broker.revoke(token);
     await broker.close();
   }
 }, 10_000);


### PR DESCRIPTION
## Summary
- move the native MCP timeout case into the focused native-tool evidence suite
- connect the stdio transport before starting the tested 1.5-second deadline
- keep production timeout and broker behavior unchanged

## Evidence
- release run 33979700914 exposed token expiry during macOS Intel process startup
- focused suite passed 15 consecutive runs
- original harness passed after extraction
- erify:release passed, including the real Markdown restoration probe and Automatic Medium Web turn