### PR TITLE
fix: preserve native Codex tables during hook migration

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -25,7 +25,7 @@
 この独立管理の **Enhanced** fork は上流リリースを追跡し、長時間実行する Codex／Claude Code
 タスク向けの Web セッションライフサイクルを追加します。fork のバージョンは
 `<upstream>-Enhanced.<revision>` 形式で、`3.0.1-Enhanced.1` から始まりました。
-現在のバージョンは上流 v5.0.4 ベースの `5.0.4-Enhanced.1` です。
+現在のバージョンは上流 v5.0.4 ベースの `5.0.4-Enhanced.2` です。
 
 Free および Go アカウントでは、Codex のネイティブモデル選択画面に
 **ChatGPT Web — Luna** が追加されます。reasoning セレクターが表示されるアカウントでは、

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 This independently maintained **Enhanced** fork tracks the upstream release base and adds an
 opt-in Web-session lifecycle for long-running Codex and Claude Code work. Fork releases use the
 `<upstream>-Enhanced.<revision>` version format, beginning with `3.0.1-Enhanced.1`.
-The current version is `5.0.4-Enhanced.1`, based on upstream v5.0.4.
+The current version is `5.0.4-Enhanced.2`, based on upstream v5.0.4.
 
 Free and Go accounts get **ChatGPT Web — Luna** in Codex's native model picker. Accounts that
 expose the reasoning selector keep **Instant**, **Medium**, **High**, **Extra High**, and **Pro** as

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -24,7 +24,7 @@
 
 这是独立维护的 **Enhanced** fork：在持续跟进上游基线的同时，提供可选的长任务 Web 会话
 生命周期。Fork 版本采用 `<上游版本>-Enhanced.<修订号>`，首个版本为 `3.0.1-Enhanced.1`。
-当前版本为基于上游 v5.0.4 的 `5.0.4-Enhanced.1`。
+当前版本为基于上游 v5.0.4 的 `5.0.4-Enhanced.2`。
 
 Free 和 Go 账户会在 Codex 原生模型选择器中看到 **ChatGPT Web — Luna**。具有推理选择器的
 账户仍会按订阅权限看到 **Instant**、**Medium**、**High**、**Extra High** 和 **Pro**。

--- a/launcher/package.json
+++ b/launcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-web-gpt-launcher",
-  "version": "5.0.4-Enhanced.1",
+  "version": "5.0.4-Enhanced.2",
   "private": true,
   "description": "Desktop control center for Codex ChatGPT Web",
   "author": "miuuyy",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-chatgpt-web",
-  "version": "5.0.4-Enhanced.1",
+  "version": "5.0.4-Enhanced.2",
   "private": true,
   "description": "A focused local Responses bridge that runs Codex tasks through a user-authenticated ChatGPT web session.",
   "repository": {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2,7 +2,7 @@
 set -eu
 
 REPOSITORY="${CODEX_CHATGPT_WEB_REPOSITORY:-Evanlau1798/codex-chatgpt-web}"
-VERSION="${CODEX_CHATGPT_WEB_VERSION:-5.0.4-Enhanced.1}"
+VERSION="${CODEX_CHATGPT_WEB_VERSION:-5.0.4-Enhanced.2}"
 BIN_DIR="${CODEX_CHATGPT_WEB_BIN_DIR:-$HOME/.local/bin}"
 LIB_DIR="${CODEX_CHATGPT_WEB_LIB_DIR:-$HOME/.local/lib/codex-chatgpt-web}"
 DOC_DIR="${CODEX_CHATGPT_WEB_DOC_DIR:-$HOME/.local/share/doc/codex-chatgpt-web}"

--- a/src/codex-interrupt-hook.ts
+++ b/src/codex-interrupt-hook.ts
@@ -170,14 +170,24 @@ function locateCodexInterruptHook(text: string, installed: InstalledCodexInterru
   const marker = installed.fragment.indexOf(MANAGED_INTERRUPT_HOOK_END);
   if (marker < 0) throw new Error("Codex interrupt lifecycle hook journal fragment is invalid");
   const ownedPrefix = installed.fragment.slice(0, marker);
-  // Native config writes normalize CRLF to LF; commands and owned fields must still match exactly.
-  const pattern = new RegExp(hookTextPattern(ownedPrefix), "g");
+  const stateTable = `[hooks.state.${JSON.stringify(installed.stateKey)}]`;
+  const stateOffset = ownedPrefix.indexOf(stateTable);
+  if (stateOffset < 0) throw new Error("Codex interrupt lifecycle hook journal fragment is invalid");
+  const hookPrefix = ownedPrefix.slice(0, stateOffset);
+  const stateSuffix = ownedPrefix.slice(stateOffset);
+  // Native config may insert unrelated tables before the hook trust table and normalizes CRLF to LF.
+  // The executable hook and trust state are compared semantically below and must still match exactly.
+  const pattern = new RegExp(
+    `${hookTextPattern(hookPrefix)}([\\s\\S]*?)${hookTextPattern(stateSuffix)}`,
+    "g",
+  );
   const match = pattern.exec(text);
   if (!match || pattern.exec(text)) {
     throw new Error("Codex interrupt lifecycle hook changed after setup; refusing to overwrite it");
   }
   const first = match.index;
   const ownedEnd = first + match[0].length;
+  const interstitialConfig = match[1] ?? "";
   if (interruptGroupCount(text.slice(0, first)) !== installed.groupIndex) {
     throw new Error("Codex interrupt lifecycle hook order changed after setup; refusing to overwrite it");
   }
@@ -189,25 +199,27 @@ function locateCodexInterruptHook(text: string, installed: InstalledCodexInterru
   if (codexInterruptHookHash(installed.command) !== installed.trustedHash) {
     throw new Error("Codex interrupt lifecycle hook journal hash is invalid");
   }
-  // Codex's TOML editor inserts new tables before trailing comments. The end marker can therefore
-  // move past unrelated config even though the owned hook fields remain unchanged.
-  const appendedConfig = text.slice(ownedEnd, endMarker);
-  const firstAssignment = appendedConfig.split(/\r\n|\n|\r/)
-    .map(line => line.trim()).find(line => line && !line.startsWith("#"));
-  if (firstAssignment && !/^\[\[?.+\]\]?(?:\s*#.*)?$/.test(firstAssignment)) {
-    throw new Error("Codex interrupt lifecycle hook changed after setup; refusing to overwrite it");
+  const trailingConfig = text.slice(ownedEnd, endMarker);
+  const insertedConfig = [interstitialConfig, trailingConfig];
+  for (const fragment of insertedConfig) {
+    const firstAssignment = fragment.split(/\r\n|\n|\r/)
+      .map(line => line.trim()).find(line => line && !line.startsWith("#"));
+    if (firstAssignment && !/^\[\[?.+\]\]?(?:\s*#.*)?$/.test(firstAssignment)) {
+      throw new Error("Codex interrupt lifecycle hook changed after setup; refusing to overwrite it");
+    }
   }
-  if (firstAssignment) {
-    // A later table can also extend the owned hook or trust state. Compare those exact
-    // definitions with Bun's TOML parser before treating the inserted tables as unrelated.
+  if (insertedConfig.some(fragment => fragment.trim())) {
+    // Inserted tables can also extend the owned hook or trust state. Compare those exact
+    // definitions with Bun's TOML parser before treating the tables as unrelated.
     const ownedDefinitions = (fragment: string): string => {
       const { hooks } = Bun.TOML.parse(fragment) as {
         hooks: { Interrupt: unknown[]; state: Record<string, unknown> };
       };
-      return JSON.stringify(canonicalJson([hooks.Interrupt[0], hooks.state[installed.stateKey]]));
+      return JSON.stringify(canonicalJson([hooks.Interrupt, hooks.state[installed.stateKey]]));
     };
     try {
-      if (ownedDefinitions(ownedPrefix) !== ownedDefinitions(ownedPrefix + appendedConfig)) {
+      const actualPrefix = hookPrefix + interstitialConfig + stateSuffix + trailingConfig;
+      if (ownedDefinitions(ownedPrefix) !== ownedDefinitions(actualPrefix)) {
         throw new Error("Modified owned definitions");
       }
     } catch {
@@ -217,7 +229,7 @@ function locateCodexInterruptHook(text: string, installed: InstalledCodexInterru
   const end = endMarker + MANAGED_INTERRUPT_HOOK_END.length;
   const trailing = installed.fragment.slice(marker + MANAGED_INTERRUPT_HOOK_END.length);
   const trailingLength = new RegExp("^" + hookTextPattern(trailing)).exec(text.slice(end))?.[0].length ?? 0;
-  return { start: first, end: end + trailingLength, appendedConfig };
+  return { start: first, end: end + trailingLength, appendedConfig: insertedConfig.join("") };
 }
 
 export function verifyCodexInterruptHook(text: string, installed: InstalledCodexInterruptHook): void {

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = "5.0.4-Enhanced.1";
+export const VERSION = "5.0.4-Enhanced.2";

--- a/tests/codex-interrupt-hook.test.ts
+++ b/tests/codex-interrupt-hook.test.ts
@@ -112,6 +112,7 @@ test("refuses to remove a modified or duplicated managed hook", () => {
   )).toThrow("changed after setup");
   for (const extension of [
     '\n[[hooks.Interrupt.hooks]]\ntype = "command"\ncommand = "unexpected-command"\n',
+    '\n[[hooks.Interrupt]]\n',
     `\n[hooks.state.${JSON.stringify(installed.installed.stateKey)}.unexpected]\nvalue = true\n`,
   ]) {
     expect(() => restoreCodexInterruptHook(
@@ -151,5 +152,31 @@ test("preserves native TOML editor tables inserted before the trailing hook comm
     expect(() => restoreCodexInterruptHook(
       edited.replace("timeout = 3", "timeout = 2"), installed.installed,
     )).toThrow("changed after setup");
+  }
+});
+
+test("preserves native model availability state inserted before the hook trust table", () => {
+  const configPath = "C:\\Users\\test\\.codex\\config.toml";
+  for (const ending of ["\n", "\r\n"]) {
+    const original = `model = "gpt-5.6-sol"${ending}`;
+    const installed = installCodexInterruptHookCommand(
+      original,
+      configPath,
+      "C:\\runtime\\codex-interrupt-hook.exe",
+    );
+    const stateTable = `[hooks.state.${JSON.stringify(installed.installed.stateKey)}]`;
+    const inserted = `[tui.model_availability_nux]${ending}gpt-6-astra = 4${ending}${ending}`;
+    const edited = installed.text.replace(stateTable, inserted + stateTable);
+
+    verifyCodexInterruptHook(edited, installed.installed);
+    const restored = restoreCodexInterruptHook(edited, installed.installed);
+    expect(restored).toBe(original + inserted);
+    const upgraded = installCodexInterruptHookCommand(
+      restored,
+      configPath,
+      "C:\\packaged\\codex-interrupt-hook.exe",
+    );
+    verifyCodexInterruptHook(upgraded.text, upgraded.installed);
+    expect(upgraded.text).toContain(inserted);
   }
 });


### PR DESCRIPTION
## Summary
- preserve Codex-owned TOML tables inserted between the managed Interrupt hook and its trust-state table
- keep exact semantic validation of the managed hook and reject duplicate Interrupt groups
- prepare v5.0.4-Enhanced.2 across runtime, launcher, installer, and multilingual README surfaces

## Root cause
Codex CLI 0.153.4 writes `[tui.model_availability_nux]` between the managed hook command and `[hooks.state.codex_chatgpt_web_interrupt]`. The v5.0.4 verifier treated the managed block as one contiguous prefix and refused the installed runtime migration, which left setup incomplete and prevented model-list and response operations.

## Verification
- focused hook/integration/setup tests: 73 passed
- focused launcher runtime-host/setup tests: 46 passed
- launcher release-origin and packaging contracts: 14 passed
- root and launcher version sync: passed
- actual Codex config migration preserves the native table and removes only the managed marker
- `bun run verify:release`: passed, including the exact candidate runtime and Automatic Medium live Web gate

The user-owned `.gitignore` change is excluded.