### PR TITLE
feat: honor codex --search with ChatGPT's Web search composer hint

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,10 @@ connects ChatGPT back to the tools of that same Codex task.
 - **No Pro exception.** Pro follows exactly the same MCP, context, image, tracing, tool-round,
   browser-ceiling, and compaction contracts as every other effort. There are no effort-specific MCP
   exclusions. Browser-only mode remains read-only for every route.
+- **Explicit web search.** `codex --search` declares the hosted Responses `web_search` tool. On a
+  browser-only turn the bridge selects ChatGPT's own **Web search** composer hint before attaching
+  the prompt, so the turn searches instead of relying on the model's discretion. Turns that attach
+  the Codex connector reject the flag with an explicit error rather than dropping it.
 - **Fail-closed with an explicit release gate.** UI drift and missing capabilities produce explicit
   errors rather than silent fallbacks. Account-bound model selection, long context, images,
   streaming, compaction, native tool rounds, cancellation, and Pro are covered by a separate
@@ -258,6 +262,9 @@ codex-chatgpt-web subagents native
 
 - This is unofficial browser automation, not an OpenAI API. ChatGPT UI changes can break selectors;
   drift fails explicitly instead of silently switching model or transport.
+- ChatGPT does not offer Deep research inside Temporary Chat, which is the only surface the bridge
+  drives, so Deep research is not routed. Web search is the only ChatGPT tool hint the bridge
+  selects on request.
 - Browser state is a sensitive login artifact, and the loopback listener is reachable by processes
   running as the same local user. Never share the launcher profile; use a trusted workstation.
 - Release packages currently target macOS 13+ (arm64/x64), Windows x64, and Linux x64. Runtime,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -26,6 +26,12 @@ launcher-owned codex-chatgpt-web daemon
 - Sends the complete Codex context and image attachments to a fresh ChatGPT Temporary Chat.
 - Never starts the broker, tunnel, or MCP server.
 - Emits a nonfatal Codex commentary warning that local tools are unavailable for the selected model.
+- Honors `codex --search`: the hosted Responses `web_search` tool is recorded as a request option,
+  never exposed to the routed model as a function, and the browser worker selects ChatGPT's own
+  **Web search** composer hint (the inline `data-system-hint-type="search"` pill) before attaching
+  the prompt. A missing menu row or pill fails the turn. Turns that attach the Codex connector
+  (full mode, the enhanced control connector, or manual Zero Risk) reject the flag explicitly.
+  Deep research is not offered in Temporary Chat and is not routed.
 
 ### `full`
 

--- a/src/adapters/chatgpt-web/adapter-runtime-factory.ts
+++ b/src/adapters/chatgpt-web/adapter-runtime-factory.ts
@@ -150,6 +150,7 @@ export function createChatGptRuntimeStarter(options: ChatGptRuntimeFactoryOption
         ...base,
         traceId,
         ...(nativeControlConnector ? { nativeConnector: true } : {}),
+        ...(parsed.options.webSearch ? { webSearch: true } : {}),
         ...(parsed._compactionRequest ? { compaction: true } : {}),
         onReasoningSummary: (value, continuation) => trace.push({ kind: "reasoning", text: value, ...(continuation ? { continuation: true } : {}) }),
         onCommentary: emitCommentary,

--- a/src/adapters/chatgpt-web/browser-helper-main.ts
+++ b/src/adapters/chatgpt-web/browser-helper-main.ts
@@ -27,6 +27,7 @@ interface RunMessage {
     reasoning?: string;
     capabilities: ChatGptWebCapabilities;
     nativeConnector?: boolean;
+    webSearch?: boolean;
     resumeAvailable?: boolean;
     retainConversation?: boolean;
     requireRetainedConversation?: boolean;
@@ -149,6 +150,9 @@ async function run(message: RunMessage): Promise<void> {
   if (message.turn.nativeConnector !== undefined && typeof message.turn.nativeConnector !== "boolean") {
     throw new Error("Browser helper Native2 connector flag is invalid");
   }
+  if (message.turn.webSearch !== undefined && typeof message.turn.webSearch !== "boolean") {
+    throw new Error("Browser helper web search flag is invalid");
+  }
   if (message.turn.retainConversation !== undefined && typeof message.turn.retainConversation !== "boolean") {
     throw new Error("Browser helper conversation retention flag is invalid");
   }
@@ -200,6 +204,7 @@ async function run(message: RunMessage): Promise<void> {
     reasoning: message.turn.reasoning,
     capabilities: message.turn.capabilities,
     ...(message.turn.nativeConnector ? { nativeConnector: true } : {}),
+    ...(message.turn.webSearch ? { webSearch: true } : {}),
     prepare: prepareSelected,
     ...(message.turn.resumeAvailable ? { prepareResume: prepareSelected } : {}),
     ...(message.turn.retainConversation ? { retainConversation: true } : {}),

--- a/src/adapters/chatgpt-web/browser-worker.ts
+++ b/src/adapters/chatgpt-web/browser-worker.ts
@@ -128,6 +128,7 @@ import { ChatGptWebAdapterError, chatGptBrowserTabClosedError, chatGptStoppedThi
 import { ChatGptAnswerBuffer } from "./browser-answer-buffer";
 import { ChatGptBrowserDiagnostics, redactChatGptUiDiagnostic } from "./browser-diagnostics";
 import { openChatGptConnectorPlusMenu } from "./connector-plus-menu";
+import { selectChatGptWebSearchHint } from "./web-search-hint";
 import {
   ChatGptBrowserObservationTimeoutError,
   MAX_CHATGPT_BROWSER_PAGE_REBINDS,
@@ -521,6 +522,8 @@ export interface BrowserTurn {
   capabilities: ChatGptWebCapabilities;
   /** Attach the Native2 connector for bridge control without granting outer Codex work capability. */
   nativeConnector?: boolean;
+  /** Select ChatGPT's own Web search composer hint before the prompt because Codex enabled `web_search`. */
+  webSearch?: boolean;
   prepare: () => Promise<CompiledChatGptWebPrompt & { release: () => void }>;
   prepareResume?: () => Promise<CompiledChatGptWebPrompt & { release: () => void }>;
   retainConversation?: boolean;
@@ -1648,7 +1651,7 @@ export class ChatGptBrowserWorker {
     return composer.evaluate(element => {
       const clone = element.cloneNode(true) as HTMLElement;
       clone.querySelectorAll(
-        '[data-id^="plugin:"][data-keyword], [data-inline-selection-pill-cursor-target]',
+        '[data-id^="plugin:"][data-keyword], [data-system-hint-type][data-keyword], [data-inline-selection-pill-cursor-target]',
       )
         .forEach(part => part.remove());
       return [...clone.childNodes]
@@ -1754,6 +1757,15 @@ export class ChatGptBrowserWorker {
         throw new Error("ChatGPT connector cleanup did not produce an empty composer");
       }
     });
+  }
+
+  private async selectWebSearchHint(
+    page: Page,
+    composer: Locator,
+    captureDiagnostic?: (checkpoint: string) => Promise<void>,
+    signal?: AbortSignal,
+  ): Promise<void> {
+    await selectChatGptWebSearchHint(page, composer, captureDiagnostic, signal);
   }
 
   private async ensureConnectorSurface(
@@ -1949,8 +1961,12 @@ export class ChatGptBrowserWorker {
     abortSignal?: AbortSignal,
     catalogRefreshAvailable = false,
     connectorAttemptBudget: ChatGptConnectorAttemptBudget = { triggerAttempts: 0 },
+    webSearch = false,
   ): Promise<void> {
     throwIfPromptAttachmentAborted(abortSignal);
+    if (webSearch && localTools) {
+      throw new Error("ChatGPT Web search hint cannot be combined with the Codex connector in one turn");
+    }
     let mutationStarted = false;
     try {
       if (!localTools || reuseConnector) {
@@ -1961,7 +1977,16 @@ export class ChatGptBrowserWorker {
         mutationStarted = true;
         await composer.fill("", { signal: abortSignal, timeout: 10_000 });
         await composer.focus();
-        await this.insertPromptText(page, prompt, abortSignal);
+        if (webSearch) {
+          // The hint is an inline pill at the start of the message; append the prompt after it the
+          // same way the connector mention path does, so verification strips the pill text.
+          await this.selectWebSearchHint(page, composer, captureDiagnostic, abortSignal);
+          await composer.focus();
+          await page.keyboard.press(CHATGPT_COMPOSER_DOCUMENT_END_KEY);
+          await this.insertPromptText(page, ` ${prompt}`, abortSignal);
+        } else {
+          await this.insertPromptText(page, prompt, abortSignal);
+        }
         await this.assertPromptAttached(page, prompt, abortSignal);
         return;
       }
@@ -2046,6 +2071,7 @@ export class ChatGptBrowserWorker {
     abortSignal?: AbortSignal,
     catalogRefreshAvailable = false,
     connectorAttemptBudget: ChatGptConnectorAttemptBudget = { triggerAttempts: 0 },
+    webSearch = false,
   ): Promise<void> {
     let retryAvailable = compaction;
     for (;;) {
@@ -2059,6 +2085,7 @@ export class ChatGptBrowserWorker {
           abortSignal,
           catalogRefreshAvailable,
           connectorAttemptBudget,
+          webSearch,
         );
         return;
       } catch (error) {
@@ -3194,6 +3221,7 @@ export class ChatGptBrowserWorker {
                 stageSignal,
                 catalogRefreshAvailable,
                 connectorAttemptBudget,
+                turn.webSearch === true,
               ),
               turn.abortSignal,
               chatGptSuspensionClock,

--- a/src/adapters/chatgpt-web/index.ts
+++ b/src/adapters/chatgpt-web/index.ts
@@ -121,6 +121,18 @@ export function createChatGptWebAdapter(
         ? { localTools: true }
         : resolveChatGptWebModelMode(parsed.modelId, parsed.options.reasoning, turnCapabilities);
       if (toolPolicy.requireTool && !mode.localTools) throw new Error("ChatGPT tool_choice requires local tools that this Web mode cannot expose");
+      // The Web search hint is a composer pill inserted before the prompt. It is proven only on the
+      // browser-only attachment path; turns that attach the Codex connector, and manual Zero Risk
+      // turns, reject the flag explicitly rather than dropping the requested search.
+      const connectorTurn = manualRequest
+        || mode.localTools
+        || (useEnhancedWebSessionMode && configuredCapabilities.localToolsEnabled);
+      if (parsed.options.webSearch && connectorTurn) {
+        throw new ChatGptWebAdapterError(
+          "Codex web search (--search) is applied only on browser-only ChatGPT Web turns without the Codex connector; disable --search for this route.",
+          { status: 400, errorType: "invalid_request_error", code: "web_search_requires_browser_only_turn", retryable: false },
+        );
+      }
       const structuredOutputValidator = parsed._compactionRequest
         ? undefined
         : createChatGptStructuredOutputValidator(parsed.options.outputFormat);

--- a/src/adapters/chatgpt-web/launcher-helper-client.ts
+++ b/src/adapters/chatgpt-web/launcher-helper-client.ts
@@ -99,6 +99,7 @@ export class LauncherBrowserHelperClient {
             reasoning: turn.reasoning,
             capabilities: turn.capabilities,
             ...(turn.nativeConnector ? { nativeConnector: true } : {}),
+            ...(turn.webSearch ? { webSearch: true } : {}),
             ...(turn.prepareResume ? { resumeAvailable: true } : {}),
             ...(turn.retainConversation ? { retainConversation: true } : {}),
             ...(turn.requireRetainedConversation ? { requireRetainedConversation: true } : {}),

--- a/src/adapters/chatgpt-web/web-search-hint.ts
+++ b/src/adapters/chatgpt-web/web-search-hint.ts
@@ -1,0 +1,81 @@
+import type { Locator, Page } from "playwright-core";
+
+/**
+ * Observed on chatgpt.com Temporary Chat (2026-09-06, Pro account, Sol composer):
+ * - The composer "+" control is `button[data-testid="composer-plus-btn"][aria-haspopup="menu"]`.
+ * - Enter opens a `div.popover` whose rows are `div.__menu-item[tabindex="0"]` elements with no
+ *   ARIA menu roles. Temporary Chat lists "Add photos & files", "Web search", and "Visualize".
+ * - Activating the "Web search" row inserts exactly one inline pill into the ProseMirror composer:
+ *   `<span data-inline-selection-pill data-id="search" data-symbol="ecosystemMention"
+ *   data-keyword="Web search" data-system-hint-type="search">Web search</span>` followed by a space.
+ *   Select-all plus Backspace removes it again.
+ */
+export const CHATGPT_WEB_SEARCH_HINT_LABEL = "Web search";
+export const CHATGPT_WEB_SEARCH_HINT_SELECTOR =
+  '[data-inline-selection-pill][data-system-hint-type="search"][data-keyword="Web search"]';
+export const CHATGPT_COMPOSER_MENU_ROW_SELECTOR = '.__menu-item[tabindex="0"]';
+
+const WEB_SEARCH_MENU_TIMEOUT_MS = 5_000;
+
+export function selectedChatGptWebSearchHint(composer: Locator): Locator {
+  return composer.locator(CHATGPT_WEB_SEARCH_HINT_SELECTOR);
+}
+
+/**
+ * Select ChatGPT's own Web search hint in an empty composer. The caller must clear the composer
+ * first and attach the prompt after the pill; the hint is part of the message, not a mode toggle.
+ * Every ambiguity fails closed so a turn never silently runs without the requested search.
+ */
+export async function selectChatGptWebSearchHint(
+  page: Page,
+  composer: Locator,
+  captureDiagnostic?: (checkpoint: string) => Promise<void>,
+  signal?: AbortSignal,
+): Promise<void> {
+  const options = { signal, timeout: WEB_SEARCH_MENU_TIMEOUT_MS };
+  const hint = selectedChatGptWebSearchHint(composer);
+  const existing = await hint.count();
+  if (existing > 1) throw new Error("ChatGPT composer exposed duplicate Web search hints");
+  if (existing === 1) {
+    await captureDiagnostic?.("web-search-hint-already-selected");
+    return;
+  }
+
+  const plus = page.getByTestId("composer-plus-btn").filter({ visible: true });
+  const plusCount = await plus.count();
+  if (plusCount === 0) throw new Error("ChatGPT composer plus control is not available; cannot select Web search");
+  if (plusCount !== 1) throw new Error("ChatGPT composer exposed duplicate plus controls");
+  await plus.focus(options);
+  await plus.press("Enter", options);
+
+  const row = page
+    .locator(CHATGPT_COMPOSER_MENU_ROW_SELECTOR)
+    .filter({ has: page.getByText(CHATGPT_WEB_SEARCH_HINT_LABEL, { exact: true }) })
+    .filter({ visible: true });
+  try {
+    await row.waitFor({ state: "visible", ...options });
+  } catch (error) {
+    await page.keyboard.press("Escape");
+    if (error instanceof Error && error.name === "TimeoutError") {
+      throw new Error("ChatGPT composer plus menu did not expose a Web search row");
+    }
+    throw error;
+  }
+  if (await row.count() !== 1) {
+    await page.keyboard.press("Escape");
+    throw new Error("ChatGPT composer plus menu exposed duplicate Web search rows");
+  }
+  await captureDiagnostic?.("web-search-menu-visible");
+  await row.click(options);
+
+  try {
+    await hint.waitFor({ state: "visible", ...options });
+  } catch (error) {
+    if (error instanceof Error && error.name === "TimeoutError") {
+      throw new Error("ChatGPT composer did not insert the Web search hint");
+    }
+    throw error;
+  }
+  if (await hint.count() !== 1) throw new Error("ChatGPT composer exposed duplicate Web search hints");
+  await captureDiagnostic?.("web-search-hint-selected");
+}

--- a/src/responses/parser.ts
+++ b/src/responses/parser.ts
@@ -99,6 +99,16 @@ function mapToolChoice(value: unknown): CodexRequestOptions["toolChoice"] {
   return undefined;
 }
 
+/**
+ * Codex `--search` declares the OpenAI-hosted Responses `web_search` tool. A routed chat model cannot
+ * execute it, so it never becomes a function tool; the ChatGPT Web adapter instead selects ChatGPT's
+ * own Web search hint for the browser turn or rejects the request explicitly.
+ */
+function requestsHostedWebSearch(tools: unknown[] | undefined): boolean {
+  return Array.isArray(tools) && tools.some(tool => isObj(tool)
+    && (tool.type === "web_search" || tool.type === "web_search_preview"));
+}
+
 function allowedToolName(tool: unknown): string | undefined {
   if (!isObj(tool)) return undefined;
   if (typeof tool.name === "string" && tool.name.length > 0) return tool.name;
@@ -216,7 +226,8 @@ function buildTools(tools: unknown[] | undefined): CodexTool[] | undefined {
       pushFn(t);
     }
     // Only the OpenAI-hosted server-side tools (web_search, image_generation) are intentionally
-    // dropped — they're executed by OpenAI and can't be relayed to a routed chat model.
+    // dropped — they're executed by OpenAI and can't be relayed to a routed chat model. A hosted
+    // web_search request is still recorded as `options.webSearch` (see requestsHostedWebSearch).
   }
   return out.length > 0 ? out : undefined;
 }
@@ -607,6 +618,9 @@ export function parseRequest(body: unknown): CodexParsedRequest {
   const tc = mapToolChoice(data.tool_choice);
   if (tc !== undefined) options.toolChoice = tc;
   if (data.parallel_tool_calls !== undefined) options.parallelToolCalls = data.parallel_tool_calls;
+  if (requestsHostedWebSearch(data.tools as unknown[] | undefined) || requestsHostedWebSearch(loadedToolSpecs)) {
+    options.webSearch = true;
+  }
   // Upstream codex-rs converts "ultra" to "max" at the inference boundary (core/src/client.rs
   // `reasoning_effort_for_request`), so current clients never send it — but a catalog that
   // advertises ultra plus an older/direct caller can. Degrade it to max like upstream instead of

--- a/src/server.ts
+++ b/src/server.ts
@@ -172,6 +172,7 @@ export async function responseRequest(
     delete parsed.context.tools;
     delete parsed.options.toolChoice;
     delete parsed.options.parallelToolCalls;
+    delete parsed.options.webSearch;
     parsed.context.messages.push({ role: "user", content: COMPACT_PROMPT, timestamp: Date.now() });
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -170,6 +170,8 @@ export interface CodexRequestOptions {
   stopSequences?: string[];
   toolChoice?: CodexToolChoice;
   parallelToolCalls?: boolean;
+  /** Codex enabled the hosted Responses `web_search` tool (`codex --search`). Routed adapters map it to their own search affordance or reject it explicitly. */
+  webSearch?: boolean;
   reasoning?: string;
   hideThinkingSummary?: boolean;
   serviceTier?: string;

--- a/tests/launcher-helper-client.test.ts
+++ b/tests/launcher-helper-client.test.ts
@@ -54,6 +54,7 @@ test("Bun daemon prepares only the resume prompt selected by the persistent Node
       if (message.turn.prepared !== undefined
         || message.turn.resumePrepared !== undefined
         || message.turn.nativeConnector !== true
+        || message.turn.webSearch !== true
         || message.turn.retainConversation !== true
         || message.turn.requireRetainedConversation !== true
         || message.turn.conversationKey !== "a".repeat(64)) {
@@ -112,6 +113,7 @@ test("Bun daemon prepares only the resume prompt selected by the persistent Node
       reasoning: "high",
       capabilities: { localToolsEnabled: false, solAvailable: true, proAvailable: false },
       nativeConnector: true,
+      webSearch: true,
       prepare: async () => {
         fullPrepareCount += 1;
         return { text: "inspect", images: [], release: () => { released = true; } };

--- a/tests/launcher-helper-roundtrip.test.ts
+++ b/tests/launcher-helper-roundtrip.test.ts
@@ -23,6 +23,7 @@ test("daemon streams browser lifecycle through the real helper process", async (
       await turn.onPreparedSelected(false);
       const prepared = await turn.prepare();
       if (prepared.multipart.parts.length !== 3) throw new Error("Multipart context was lost");
+      if (turn.webSearch !== true) throw new Error("Web search flag was lost");
       await turn.onMultipartStageAcknowledged?.(1);
       await turn.onMultipartStageAcknowledged?.(2);
       await turn.onSendActivated();
@@ -89,6 +90,7 @@ test("daemon streams browser lifecycle through the real helper process", async (
       modelId: "gpt-5.6-sol",
       reasoning: "high",
       capabilities: { localToolsEnabled: false, solAvailable: true, proAvailable: false },
+      webSearch: true,
       prepare: async () => ({
         text: "inspect", images: [],
         multipart: { parts: ["part one", "part two", "part three"], commit: "inspect" },

--- a/tests/responses-web-search.test.ts
+++ b/tests/responses-web-search.test.ts
@@ -1,0 +1,47 @@
+import { expect, test } from "bun:test";
+import { parseRequest } from "../src/responses/parser";
+
+const readTool = { type: "function", name: "read", description: "Read a file", parameters: { type: "object", properties: {} } };
+
+test("hosted web_search from `codex --search` becomes options.webSearch and never a function tool", () => {
+  const parsed = parseRequest({
+    model: "chatgpt-web/high",
+    input: "What changed in the latest release?",
+    tools: [{ type: "web_search" }, readTool],
+  });
+
+  expect(parsed.options.webSearch).toBe(true);
+  expect(parsed.context.tools?.map(tool => tool.name)).toEqual(["read"]);
+});
+
+test("the legacy web_search_preview tool type is treated the same way", () => {
+  const parsed = parseRequest({
+    model: "chatgpt-web/high",
+    input: "What changed in the latest release?",
+    tools: [{ type: "web_search_preview" }],
+  });
+
+  expect(parsed.options.webSearch).toBe(true);
+  expect(parsed.context.tools).toBeUndefined();
+});
+
+test("web_search riding inside a Responses Lite additional_tools item is detected too", () => {
+  const parsed = parseRequest({
+    model: "chatgpt-web/luna",
+    input: [{ type: "additional_tools", role: "developer", tools: [{ type: "web_search" }, readTool] }],
+  });
+
+  expect(parsed.options.webSearch).toBe(true);
+  expect(parsed.context.tools?.map(tool => tool.name)).toEqual(["read"]);
+});
+
+test("requests without a hosted web_search tool leave options.webSearch unset", () => {
+  const parsed = parseRequest({
+    model: "chatgpt-web/high",
+    input: "Explain the diff",
+    tools: [readTool, { type: "image_generation" }],
+  });
+
+  expect(parsed.options.webSearch).toBeUndefined();
+  expect(parsed.context.tools?.map(tool => tool.name)).toEqual(["read"]);
+});

--- a/tests/web-search-hint.test.ts
+++ b/tests/web-search-hint.test.ts
@@ -1,0 +1,219 @@
+import { expect, test } from "bun:test";
+import { CHATGPT_COMPOSER_DOCUMENT_END_KEY, ChatGptBrowserWorker } from "../src/adapters/chatgpt-web/browser-worker";
+import {
+  CHATGPT_COMPOSER_MENU_ROW_SELECTOR,
+  CHATGPT_WEB_SEARCH_HINT_SELECTOR,
+  selectChatGptWebSearchHint,
+} from "../src/adapters/chatgpt-web/web-search-hint";
+
+class TimeoutError extends Error {
+  override name = "TimeoutError";
+}
+
+function hintFixture(options: { hintCounts: number[]; rowVisible: boolean; rowCount?: number }) {
+  const calls: string[] = [];
+  const hintCounts = [...options.hintCounts];
+  const hint = {
+    count: async () => hintCounts.shift() ?? 0,
+    waitFor: async () => {
+      calls.push("hint:waitFor");
+      if ((hintCounts[0] ?? 0) === 0) throw new TimeoutError("hint missing");
+    },
+  };
+  const composer = {
+    locator: (selector: string) => {
+      expect(selector).toBe(CHATGPT_WEB_SEARCH_HINT_SELECTOR);
+      return hint;
+    },
+  };
+  const row = {
+    waitFor: async () => {
+      calls.push("row:waitFor");
+      if (!options.rowVisible) throw new TimeoutError("row missing");
+    },
+    count: async () => options.rowCount ?? 1,
+    click: async () => { calls.push("row:click"); },
+  };
+  const textMatcher = { exact: true, text: "Web search" };
+  const page = {
+    getByTestId: (testId: string) => {
+      expect(testId).toBe("composer-plus-btn");
+      return {
+        filter: (filterOptions: { visible: boolean }) => {
+          expect(filterOptions).toEqual({ visible: true });
+          return {
+            count: async () => 1,
+            focus: async () => { calls.push("plus:focus"); },
+            press: async (key: string) => { calls.push(`plus:${key}`); },
+          };
+        },
+      };
+    },
+    getByText: (text: string, textOptions: { exact: boolean }) => {
+      expect(text).toBe("Web search");
+      expect(textOptions).toEqual({ exact: true });
+      return textMatcher;
+    },
+    locator: (selector: string) => {
+      expect(selector).toBe(CHATGPT_COMPOSER_MENU_ROW_SELECTOR);
+      return {
+        filter: (hasOptions: { has: unknown }) => {
+          expect(hasOptions).toEqual({ has: textMatcher });
+          return {
+            filter: (visibleOptions: { visible: boolean }) => {
+              expect(visibleOptions).toEqual({ visible: true });
+              return row;
+            },
+          };
+        },
+      };
+    },
+    keyboard: {
+      press: async (key: string) => { calls.push(`keyboard:${key}`); },
+    },
+  };
+  return { page, composer, calls };
+}
+
+test("Web search hint opens the plus menu, activates the exact row, and verifies the inserted pill", async () => {
+  const { page, composer, calls } = hintFixture({ hintCounts: [0, 1, 1], rowVisible: true });
+  const checkpoints: string[] = [];
+
+  await selectChatGptWebSearchHint(page as never, composer as never, async checkpoint => { checkpoints.push(checkpoint); });
+
+  expect(calls).toEqual(["plus:focus", "plus:Enter", "row:waitFor", "row:click", "hint:waitFor"]);
+  expect(checkpoints).toEqual(["web-search-menu-visible", "web-search-hint-selected"]);
+});
+
+test("Web search hint is idempotent when the composer already carries the pill", async () => {
+  const { page, composer, calls } = hintFixture({ hintCounts: [1], rowVisible: true });
+  const checkpoints: string[] = [];
+
+  await selectChatGptWebSearchHint(page as never, composer as never, async checkpoint => { checkpoints.push(checkpoint); });
+
+  expect(calls).toEqual([]);
+  expect(checkpoints).toEqual(["web-search-hint-already-selected"]);
+});
+
+test("Web search hint fails closed and dismisses the menu when the row is missing", async () => {
+  const { page, composer, calls } = hintFixture({ hintCounts: [0], rowVisible: false });
+
+  await expect(selectChatGptWebSearchHint(page as never, composer as never))
+    .rejects.toThrow("ChatGPT composer plus menu did not expose a Web search row");
+  expect(calls).toEqual(["plus:focus", "plus:Enter", "row:waitFor", "keyboard:Escape"]);
+});
+
+test("Web search hint fails closed when activating the row inserts no pill", async () => {
+  const { page, composer, calls } = hintFixture({ hintCounts: [0, 0, 0], rowVisible: true });
+
+  await expect(selectChatGptWebSearchHint(page as never, composer as never))
+    .rejects.toThrow("ChatGPT composer did not insert the Web search hint");
+  expect(calls).toEqual(["plus:focus", "plus:Enter", "row:waitFor", "row:click", "hint:waitFor"]);
+});
+
+test("Web search hint rejects duplicate menu rows before activating anything", async () => {
+  const { page, composer, calls } = hintFixture({ hintCounts: [0], rowVisible: true, rowCount: 2 });
+
+  await expect(selectChatGptWebSearchHint(page as never, composer as never))
+    .rejects.toThrow("ChatGPT composer plus menu exposed duplicate Web search rows");
+  expect(calls).toEqual(["plus:focus", "plus:Enter", "row:waitFor", "keyboard:Escape"]);
+});
+
+type AttachPrompt = (
+  page: unknown,
+  prompt: string,
+  localTools: boolean,
+  captureDiagnostic?: (checkpoint: string) => Promise<void>,
+  reuseConnector?: boolean,
+  abortSignal?: AbortSignal,
+  catalogRefreshAvailable?: boolean,
+  connectorAttemptBudget?: { triggerAttempts: number },
+  webSearch?: boolean,
+) => Promise<void>;
+
+const attachPrompt = (ChatGptBrowserWorker.prototype as unknown as { attachPrompt: AttachPrompt }).attachPrompt;
+
+test("browser-only prompt attachment selects the Web search hint between clearing and inserting the prompt", async () => {
+  const calls: Array<string | string[]> = [];
+  const composer = {
+    fill: async (value: string) => { calls.push(["fill", value]); },
+    focus: async () => { calls.push("composer:focus"); },
+  };
+  const page = { keyboard: { press: async (key: string) => { calls.push(`keyboard:${key}`); } } };
+  const worker = {
+    activeComposer: async () => composer,
+    selectWebSearchHint: async (hintPage: unknown, hintComposer: unknown) => {
+      expect(hintPage).toBe(page);
+      expect(hintComposer).toBe(composer);
+      calls.push("hint:select");
+    },
+    insertPromptText: async (_page: unknown, text: string) => { calls.push(["insert", text]); },
+    assertPromptAttached: async (_page: unknown, prompt: string) => { calls.push(["assert", prompt]); },
+  };
+
+  await attachPrompt.call(worker, page, "Summarize the release notes", false, undefined, false, undefined, false, { triggerAttempts: 0 }, true);
+
+  expect(calls).toEqual([
+    ["fill", ""],
+    "composer:focus",
+    "hint:select",
+    "composer:focus",
+    `keyboard:${CHATGPT_COMPOSER_DOCUMENT_END_KEY}`,
+    ["insert", " Summarize the release notes"],
+    ["assert", "Summarize the release notes"],
+  ]);
+});
+
+test("prompt attachment without the flag never touches the plus menu", async () => {
+  const calls: Array<string | string[]> = [];
+  const composer = {
+    fill: async (value: string) => { calls.push(["fill", value]); },
+    focus: async () => { calls.push("composer:focus"); },
+  };
+  const worker = {
+    activeComposer: async () => composer,
+    selectWebSearchHint: async () => { calls.push("hint:select"); },
+    insertPromptText: async (_page: unknown, text: string) => { calls.push(["insert", text]); },
+    assertPromptAttached: async (_page: unknown, prompt: string) => { calls.push(["assert", prompt]); },
+  };
+
+  await attachPrompt.call(worker, {}, "Plain prompt", false);
+
+  expect(calls).toEqual([["fill", ""], "composer:focus", ["insert", "Plain prompt"], ["assert", "Plain prompt"]]);
+});
+
+test("prompt verification strips the observed Web search pill before comparing the composer text", async () => {
+  const { createDocument } = require("@mixmark-io/domino") as {
+    createDocument: (html: string) => Document;
+  };
+  // Composer markup captured from chatgpt.com Temporary Chat on 2026-09-06 after activating the
+  // "Web search" plus-menu row and appending the prompt after the pill.
+  const document = createDocument(
+    '<div id="prompt-textarea" contenteditable="true" role="textbox"><p dir="auto">'
+      + '<span data-inline-selection-pill-cursor-target="" aria-hidden="true" contenteditable="false">\uFEFF</span>'
+      + '<span contenteditable="false" data-inline-selection-pill="" data-id="search" data-symbol="ecosystemMention"'
+      + ' data-keyword="Web search" data-system-hint-type="search">'
+      + '<span class="max-w-[16rem] self-baseline truncate">Web search</span></span> Summarize the release notes</p></div>',
+  );
+  const composerElement = document.getElementById("prompt-textarea")!;
+  const attachedPromptText = (ChatGptBrowserWorker.prototype as unknown as {
+    attachedPromptText(page: unknown): Promise<string>;
+  }).attachedPromptText;
+  const worker = {
+    activeComposer: async () => ({
+      evaluate: async (callback: (element: Element) => string) => callback(composerElement),
+    }),
+  };
+
+  expect(await attachedPromptText.call(worker, {})).toBe("Summarize the release notes");
+  expect(composerElement.textContent).toContain("Web search");
+});
+
+test("prompt attachment refuses to combine the Web search hint with the Codex connector", async () => {
+  const worker = {
+    activeComposer: async () => { throw new Error("composer must not be touched"); },
+  };
+
+  await expect(attachPrompt.call(worker, {}, "prompt", true, undefined, false, undefined, false, { triggerAttempts: 0 }, true))
+    .rejects.toThrow("ChatGPT Web search hint cannot be combined with the Codex connector in one turn");
+});


### PR DESCRIPTION
`codex --search` now does what it says on a routed ChatGPT Web turn: the bridge selects ChatGPT's own **Web search** composer hint before attaching the prompt, so the turn is forced to search instead of leaving it to the model's discretion. Deep research stays out of scope because ChatGPT does not offer it inside Temporary Chat, the only surface this bridge drives.

## Why

Codex declares the hosted Responses `web_search` tool when `--search` is on. The parser already dropped that tool because a routed chat model cannot execute it, which meant the flag was silently ignored on every `chatgpt-web/*` route. Browser-only turns could still search when the model felt like it, but there was no way to require it, and a user who passed `--search` got no signal that nothing happened. This change gives the flag one explicit meaning per route and fails closed everywhere it cannot be honored.

## What changed

- **Responses parser** (`src/responses/parser.ts`, `src/types.ts`): a hosted `web_search` or `web_search_preview` entry in `tools`, or inside a Responses Lite `additional_tools` item, sets `options.webSearch = true`. The entry is still never exposed to the routed model as a function tool.
- **Adapter guard** (`src/adapters/chatgpt-web/index.ts`): the hint is proven only on the browser-only attachment path. A turn that attaches the Codex connector (full mode, the enhanced control connector, or manual Zero Risk) rejects the flag with HTTP `400` / `web_search_requires_browser_only_turn` instead of dropping it.
- **Compaction** (`src/server.ts`): summarization turns clear the flag alongside `tool_choice` and `parallel_tool_calls`, so a compaction pass never opens the composer menu.
- **Turn threading**: `BrowserTurn.webSearch` travels daemon → `launcher-helper-client` → helper process (`browser-helper-main` validates it as a boolean) → browser worker, following the exact pattern of `nativeConnector`.
- **Browser worker** (`src/adapters/chatgpt-web/browser-worker.ts`, new `web-search-hint.ts`): after the composer is cleared, the worker opens the composer `+` menu, activates the exact **Web search** row, verifies that exactly one hint pill was inserted, moves the caret to the document end, and appends the prompt after the pill the same way the connector-mention path does. Prompt verification now strips `[data-system-hint-type][data-keyword]` pills next to the existing `plugin:` connector pills, so the composer text still has to equal the prompt byte for byte.
- **Docs**: README highlights and limitations, `docs/architecture.md` browser-only section.

```mermaid
flowchart LR
    A["codex --search"] --> B["Responses tools: {type: web_search}"]
    B --> C["parser: options.webSearch = true, tool dropped"]
    C --> D{"route attaches\nCodex connector?"}
    D -- yes --> E["400 web_search_requires_browser_only_turn"]
    D -- no --> F["BrowserTurn.webSearch → helper → worker"]
    F --> G["clear composer → + menu → Web search row"]
    G --> H{"exactly one\nhint pill?"}
    H -- no --> I["turn fails"]
    H -- yes --> J["End → append prompt → verify text"]
```

## Observed DOM evidence

Captured on chatgpt.com Temporary Chat on 2026-09-06 with a Pro account and the Sol composer, through the launcher's own surface lease. Nothing was sent.

| Element | Observed markup |
| --- | --- |
| Composer `+` control | `button#composer-plus-btn[data-testid="composer-plus-btn"][aria-haspopup="menu"]`, `aria-label="Add files and more"`; Enter toggles `aria-expanded` |
| Menu container | `div.popover` positioned under `#thread-bottom`; rows are `div.__menu-item[tabindex="0"]` with **no** ARIA menu roles (only `role="group"` wrappers) |
| Temporary Chat rows | `Add photos & files`, `Web search` ("Find real-time news and info"), `Visualize`; keyboard input filters the rows through the composer itself |
| Regular chat rows | adds `Add from library`, `Create image`, `Maps`, `Deep research` ("Get a detailed report"), and connected apps |
| Web search row | `<span class="… text-token-text-primary">Web search</span>` inside the row, icon `#skill-globe-light` |
| Inserted pill | `<span contenteditable="false" data-inline-selection-pill data-id="search" data-symbol="ecosystemMention" data-keyword="Web search" data-system-hint-type="search">Web search</span>` followed by a space inside `#prompt-textarea`; the cursor-target span already stripped by prompt verification precedes it |
| Deep research pill (regular chat only) | same shape with `data-id="plugin:connector_openai_deep_research"` and `data-system-hint-type="plugin:connector_openai_deep_research"` |
| Removal | select-all plus Backspace clears the pill, so the existing composer cleanup keeps working |

The selector set is limited to what was observed: the existing `.__menu-item[tabindex="0"]` row shape the connector path already uses, an exact-text match on `Web search`, and the pill attributes above. Every ambiguity (no `+` control, duplicate controls, missing or duplicate row, missing or duplicate pill) fails the turn with a specific error and dismisses the menu.

## Behavior matrix

| Request | Route | Result |
| --- | --- | --- |
| no `--search` | any | unchanged |
| `--search` | browser-only turn (no connector) | Web search pill + prompt, verified, then sent |
| `--search` | full mode, enhanced control connector, or Zero Risk | `400 web_search_requires_browser_only_turn` before any browser work |
| `--search` | compaction pass | flag cleared; plain summarization turn |
| `--search` | menu row or pill missing / duplicated | explicit error, composer cleaned up, no send |

## Deep research

The `+` menu inside Temporary Chat does not list Deep research, the composer's keyboard filter finds no match for it, and the `/` command list offers only composer commands. Deep research appears only in a regular (history-backed) chat, which the bridge deliberately never uses. Routing it would require leaving Temporary Chat and a multi-turn clarify-then-report interaction that does not fit the single-answer turn contract, so this PR documents the limitation rather than adding a route. The interaction also shows that the current Temporary Chat `+` menu exposes no `menuitemradio` rows, which the connector plus-menu helper currently looks for; that path is untouched here and noted for a separate look.

## Tests

- `tests/web-search-hint.test.ts`: happy path (focus, Enter, exact row, click, pill verified), idempotent when the pill is already present, fail-closed when the row is missing (menu dismissed), when no pill appears, and when rows are duplicated; `attachPrompt` ordering with the flag (clear, hint, focus, End, prompt appended after a space, verify), unchanged ordering without it, refusal to combine the hint with the connector path; and a `@mixmark-io/domino` fixture built from the captured composer markup proving prompt verification strips the pill and sees only the prompt.
- `tests/responses-web-search.test.ts`: `web_search`, `web_search_preview`, and Responses Lite `additional_tools` all set `options.webSearch` without leaking a function tool; requests without it leave the option unset.
- `tests/launcher-helper-client.test.ts` and `tests/launcher-helper-roundtrip.test.ts`: the flag survives the daemon → helper protocol in both the scripted helper and the real helper process.
